### PR TITLE
Add support for CloudWatch Metric Metadata and Alarm Recommendations

### DIFF
--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_metrics/data/metric_metadata.json
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_metrics/data/metric_metadata.json
@@ -1,0 +1,13883 @@
+[
+  {
+    "metricId": {
+      "metricName": "scheduler_schedule_attempts_total",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of total attempts by the scheduler to schedule Pods in the cluster for a given period. This metric helps monitor the scheduler’s workload and can indicate scheduling pressure or potential issues with Pod placement.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "scheduler_schedule_attempts_SCHEDULED",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of successful attempts by the scheduler to schedule Pods to nodes in the cluster for a given period.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "scheduler_schedule_attempts_UNSCHEDULABLE",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of attempts to schedule Pods that were unschedulable for a given period due to valid constraints, such as insufficient CPU or memory on a node.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "scheduler_schedule_attempts_ERROR",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of attempts to schedule Pods that failed for a given period due to an internal problem with the scheduler itself, such as API Server connectivity issues.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "scheduler_pending_pods",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of total pending Pods to be scheduled by the scheduler in the cluster for a given period.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "scheduler_pending_pods_ACTIVEQ",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of pending Pods in activeQ, that are waiting to be scheduled in the cluster for a given period.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "scheduler_pending_pods_UNSCHEDULABLE",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of pending Pods that the scheduler attempted to schedule and failed, and are kept in an unschedulable state for retry.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "scheduler_pending_pods_BACKOFF",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of pending Pods in `backoffQ` in a backoff state that are waiting for their backoff period to expire.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "scheduler_pending_pods_GATED",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of pending Pods that are currently waiting in a gated state as they cannot be scheduled until they meet required conditions.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_total",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of HTTP requests made across all the API servers in the cluster.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_total_4XX",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of HTTP requests made to all the API servers in the cluster that resulted in `4XX` (client error) status codes.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_total_429",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of HTTP requests made to all the API servers in the cluster that resulted in `429` status code, which occurs when clients exceed the rate limiting thresholds.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_total_5XX",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of HTTP requests made to all the API servers in the cluster that resulted in `5XX` (server error) status codes.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_total_LIST_PODS",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of `LIST` Pods requests made to all the API servers in the cluster.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_duration_seconds_PUT_P99",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The 99th percentile of latency for `PUT` requests calculated from all requests across all API servers in the cluster. Represents the response time below which 99% of all `PUT` requests are completed.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_duration_seconds_PATCH_P99",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The 99th percentile of latency for `PATCH` requests calculated from all requests across all API servers in the cluster. Represents the response time below which 99% of all `PATCH` requests are completed.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_duration_seconds_POST_P99",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The 99th percentile of latency for `POST` requests calculated from all requests across all API servers in the cluster. Represents the response time below which 99% of all `POST` requests are completed.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_duration_seconds_GET_P99",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The 99th percentile of latency for `GET` requests calculated from all requests across all API servers in the cluster. Represents the response time below which 99% of all `GET` requests are completed.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_duration_seconds_LIST_P99",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The 99th percentile of latency for `LIST` requests calculated from all requests across all API servers in the cluster. Represents the response time below which 99% of all `LIST` requests are completed.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_duration_seconds_DELETE_P99",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The 99th percentile of latency for `DELETE` requests calculated from all requests across all API servers in the cluster. Represents the response time below which 99% of all `DELETE` requests are completed.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_current_inflight_requests_MUTATING",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of mutating requests (`POST`, `PUT`, `DELETE`, `PATCH`) currently being processed across all API servers in the cluster. This metric represents requests that are in-flight and haven’t completed processing yet.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_current_inflight_requests_READONLY",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of read-only requests (`GET`, `LIST`) currently being processed across all API servers in the cluster. This metric represents requests that are in-flight and haven’t completed processing yet.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_admission_webhook_request_total",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of admission webhook requests made across all API servers in the cluster.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_admission_webhook_request_total_ADMIT",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of mutating admission webhook requests made across all API servers in the cluster.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_admission_webhook_request_total_VALIDATING",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of validating admission webhook requests made across all API servers in the cluster.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_admission_webhook_rejection_count",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of admission webhook requests made across all API servers in the cluster that were rejected.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_admission_webhook_rejection_count_ADMIT",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of mutating admission webhook requests made across all API servers in the cluster that were rejected.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_admission_webhook_rejection_count_VALIDATING",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The number of validating admission webhook requests made across all API servers in the cluster that were rejected.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_admission_webhook_admission_duration_seconds",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The 99th percentile of latency for third-party admission webhook requests calculated from all requests across all API servers in the cluster. Represents the response time below which 99% of all third-party admission webhook requests are completed.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_admission_webhook_admission_duration_seconds_ADMIT_P99",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The 99th percentile of latency for third-party mutating admission webhook requests calculated from all requests across all API servers in the cluster. Represents the response time below which 99% of all third-party mutating admission webhook requests are completed.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_admission_webhook_admission_duration_seconds_VALIDATING_P99",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The 99th percentile of latency for third-party validating admission webhook requests calculated from all requests across all API servers in the cluster. Represents the response time below which 99% of all third-party validating admission webhook requests are completed.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_storage_size_bytes",
+      "namespace": "AWS/EKS"
+    },
+    "description": "The physical size in bytes of the etcd storage database file used by the API servers in the cluster. This metric represents the actual disk space allocated for the storage.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUUtilization",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The percentage of CPU utilization for the entire host. Because Valkey and Redis OSS are single-threaded, we recommend you monitor `EngineCPUUtilization` metric for nodes with 4 or more vCPUs.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor the CPU utilization for the entire ElastiCache instance, including the database engine processes and other processes running on the instance. AWS ElastiCache supports two engine types: Memcached and Redis. When you reach high CPU utilization on a Memcached node, you should consider scaling up your instance type or adding new cache nodes. For Redis, if your main workload is from read requests, you should consider adding more read replicas to your cache cluster. If your main workload is from write requests, you should consider adding more shards to distribute the workload across more primary nodes if you’re running in clustered mode, or scaling up your instance type if you’re running Redis in non-clustered mode.",
+        "threshold": {
+          "justification": "Set the threshold to the percentage that reflects a critical CPU utilization level for your application. For Memcached, the engine can use up to num_threads cores. For Redis, the engine is largely single-threaded, but might use additional cores if available to accelerate I/O. In most cases, you can set the threshold to about 90% of your available CPU. Because Redis is single-threaded, the actual threshold value should be calculated as a fraction of the node's total capacity."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "CacheClusterId"
+          },
+          {
+            "name": "CacheNodeId"
+          }
+        ],
+        "intent": "This alarm is used to detect high CPU utilization of ElastiCache hosts. It is useful to get a broad view of the CPU usage across the entire instance, including non-engine processes."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "CPUCreditBalance",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of earned CPU credits that an instance has accrued since it was launched or started. For T2 Standard, the CPUCreditBalance also includes the number of launch credits that have been accrued. Credits are accrued in the credit balance after they are earned, and removed from the credit balance when they are spent. The credit balance has a maximum limit, determined by the instance size. After the limit is reached, any new credits that are earned are discarded. For T2 Standard, launch credits do not count towards the limit. The credits in the CPUCreditBalance are available for the instance to spend to burst beyond its baseline CPU utilization. CPU credit metrics are available at a five-minute frequency only. This metrics is not available for T2 burstable performance instances.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Credits (vCPU-minutes)"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUCreditUsage",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of CPU credits spent by the instance for CPU utilization. One CPU credit equals one vCPU running at 100% utilization for one minute or an equivalent combination of vCPUs, utilization, and time (for example, one vCPU running at 50% utilization for two minutes or two vCPUs running at 25% utilization for two minutes). CPU credit metrics are available at a five-minute frequency only. If you specify a period greater than five minutes, use the Sum statistic instead of the Average statistic. This metrics is not available for T2 burstable performance instances.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Credits (vCPU-minutes)"
+  },
+  {
+    "metricId": {
+      "metricName": "FreeableMemory",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The amount of free memory available on the host. This is derived from the RAM, buffers, and cache that the OS reports as freeable.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkBytesIn",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of bytes the host has read from the network.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkBytesOut",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of bytes sent out on all network interfaces by the instance.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkPacketsIn",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of packets received on all network interfaces by the instance. This metric identifies the volume of incoming traffic in terms of the number of packets on a single instance.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkPacketsOut",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of packets sent out on all network interfaces by the instance. This metric identifies the volume of outgoing traffic in terms of the number of packets on a single instance.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkBandwidthInAllowanceExceeded",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of packets queued or dropped because the inbound aggregate bandwidth exceeded the maximum for the instance.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkConntrackAllowanceExceeded",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of packets dropped because connection tracking exceeded the maximum for the instance and new connections could not be established. This can result in packet loss for traffic to or from the instance.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkLinkLocalAllowanceExceeded",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of packets dropped because the PPS of the traffic to local proxy services exceeded the maximum for the network interface. This impacts traffic to the DNS service, the Instance Metadata Service, and the Amazon Time Sync Service.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkBandwidthOutAllowanceExceeded",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of packets queued or dropped because the outbound aggregate bandwidth exceeded the maximum for the instance.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkPacketsPerSecondAllowanceExceeded",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of packets queued or dropped because the bidirectional packets per second exceeded the maximum for the instance.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SwapUsage",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The amount of swap used on the host.",
+    "recommendedStatistics": "Average, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ActiveDefragHits",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of value reallocations per minute performed by the active defragmentation process. This is derived from `active_defrag_hits` statistic at INFO.",
+    "recommendedStatistics": "Average, Maximum, Sum",
+    "unitInfo": "Number"
+  },
+  {
+    "metricId": {
+      "metricName": "AuthenticationFailures",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of failed attempts to authenticate to Valkey or Redis OSS using the AUTH command. You can find more information about individual authentication failures using the ACL LOG command. We suggest setting an alarm on this to detect unauthorized access attempts.",
+    "recommendedStatistics": "Sum, Average, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesUsedForCache",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of bytes allocated by Valkey or Redis OSS for all purposes, including the dataset, buffers, and so on. `Dimension: Tier=Memory` for Valkey or Redis OSS clusters using [Data tiering in ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/data-tiering.html): The total number of bytes used for cache by memory. This is the value of `used_memory` statistic at INFO. `Dimension: Tier=SSD` for Valkey or Redis OSS clusters using [Data tiering in ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/data-tiering.html): The total number of bytes used for cache by SSD.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesReadFromDisk",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of bytes read from disk per minute. Supported only for clusters using [Data tiering in ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/data-tiering.html).",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesWrittenToDisk",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of bytes written to disk per minute. Supported only for clusters using [Data tiering in ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/data-tiering.html).",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "CacheHits",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of successful read-only key lookups in the main dictionary. This is derived from `keyspace_hits` statistic at INFO.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CacheMisses",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of unsuccessful read-only key lookups in the main dictionary. This is derived from `keyspace_misses` statistic at INFO.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CommandAuthorizationFailures",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of failed attempts by users to run commands they don’t have permission to call. You can find more information about individual authentication failures using the ACL LOG command. We suggest setting an alarm on this to detect unauthorized access attempts.",
+    "recommendedStatistics": "Sum, Average, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CacheHitRate",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Indicates the usage efficiency of the Valkey or Redis OSS instance. If the cache ratio is lower than about 0.8, it means that a significant amount of keys are evicted, expired, or don't exist. This is calculated using `cache_hits` and `cache_misses` statistics in the following way: `cache_hits /(cache_hits + cache_misses)`.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "ChannelAuthorizationFailures",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of failed attempts by users to access channels they do not have permission to access. You can find more information about individual authentication failures using the ACL LOG command. We suggest setting an alarm on this metric to detect unauthorized access attempts.",
+    "recommendedStatistics": "Sum, Average, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CurrConnections",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "For ElastiCache Redis, this metric represents the number of client connections, excluding connections from read replicas. ElastiCache uses 2 to 4 of the connections to monitor the cluster in each case. This is derived from the `connected_clients` statistic at INFO. For ElastiCache Memcached, this metric represents a count of the number of connections connected to the cache at an instant in time. ElastiCache uses 2 to 3 of the connections to monitor the cluster. In addition to the above, memcached creates a number of internal connections equal to twice the threads used for the node type. The thread count for the various node types can be see in the `Nodetype Specific Parameters` of the applicable Parameter Group. The total connections is the sum of client connections, the connections for monitoring and the internal connections mentioned above.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects high connection count, which might indicate heavy load or performance issues. A constant increase of `CurrConnections` might lead to exhaustion of the 65,000 available connections. It may indicate that connections improperly closed on the application side and were left established on the server side. You should consider using connection pooling or idle connection timeouts to limit the number of connections made to the cluster, or for Redis, consider tuning [tcp-keepalive](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ParameterGroups.Redis.html) on your cluster to detect and terminate potential dead peers.",
+        "threshold": {
+          "justification": "The recommended threshold value for this alarm is highly dependent on the acceptable range of connections for your cluster. Review the capacity and the expected workload of your ElastiCache cluster and analyze the historical connection counts during regular usage to establish a baseline, and then select a threshold accordingly. Remember that each node can support up to 65,000 concurrent connections."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "CacheClusterId"
+          },
+          {
+            "name": "CacheNodeId"
+          }
+        ],
+        "intent": "The alarm helps you identify high connection counts that could impact the performance and stability of your ElastiCache cluster."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "CurrItems",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of items in the cache. For ElastiCache Redis, this is derived from the `keyspace` statistic, summing all of the keys in the entire keyspace. For clusters using [Data tiering in ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/data-tiering.html), `Dimension: Tier=Memory` refers to number of items in memory, and `Dimension: Tier=SSD` (solid state drives) refers to number of items in SSD.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CurrVolatileItems",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Total number of keys in all databases that have a ttl set. This is derived from the `expires` statistic, summing all of the keys with a ttl set in the entire keyspace.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DatabaseCapacityUsagePercentage",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Percentage of the total data capacity for the cluster that is in use. On Data Tiered instances, the metric is calculated as `(used_memory - mem_not_counted_for_evict + SSD used) / (maxmemory + SSD total capacity)`, where `used_memory` and `maxmemory` are taken from INFO. In all other cases, the metric is calculated using `used_memory/maxmemory`.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "DatabaseCapacityUsageCountedForEvictPercentage",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Percentage of the total data capacity for the cluster that is in use, excluding the memory used for overhead and COB. This metric is calculated as: `used_memory - mem_not_counted_for_evict/maxmemory`. On Data Tiered instances, the metric is calculated as: `(used_memory + SSD used) / (maxmemory + SSD total capacity)`. where `used_memory` and `maxmemory` are taken from INFO.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "DatabaseMemoryUsagePercentage",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Percentage of the memory for the cluster that is in use. This is calculated using `used_memory/maxmemory` from INFO.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you monitor the memory utilization of your cluster. When your `DatabaseMemoryUsagePercentage` reaches 100%, the Redis maxmemory policy is triggered and evictions might occur based on the policy selected. If no object in the cache matches the eviction policy, write operations fail. Some workloads expect or rely on evictions, but if not, you will need to increase the memory capacity of your cluster. You can scale your cluster out by adding more primary nodes, or scale it up by using a larger node type. Refer to [Scaling ElastiCache for Redis clusters](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Scaling.html) for details.",
+        "threshold": {
+          "justification": "Depending on your application’s memory requirements and the memory capacity of your ElastiCache cluster, you should set the threshold to the percentage that reflects the critical level of memory usage of the cluster. You can use historical memory usage data as reference for acceptable memory usage threshold."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "CacheClusterId"
+          }
+        ],
+        "intent": "This alarm is used to detect high memory utilization of your cluster so that you can avoid failures when writing to your cluster. It is useful to know when you’ll need to scale up your cluster if your application does not expect to experience evictions."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "DatabaseMemoryUsageCountedForEvictPercentage",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Percentage of the memory for the cluster that is in use, excluding memory used for overhead and COB. This is calculated using `used_memory-mem_not_counted_for_evict/maxmemory` from INFO.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "DB0AverageTTL",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Exposes `avg_ttl` of DBO from the `keyspace` statistic of INFO command. Replicas don't expire keys, instead they wait for primary nodes to expire keys. When a primary node expires a key (or evicts it because of LRU), it synthesizes a `DEL` command, which is transmitted to all the replicas. Therefore, DB0AverageTTL is 0 for replica nodes, due the fact that they don't expire keys, and thus don't track TTL.",
+    "recommendedStatistics": "Average, Maximum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "EngineCPUUtilization",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Provides CPU utilization of the Valkey or Redis OSS engine thread. Because Valkey and Redis OSS are single-threaded, you can use this metric to analyze the load of the process itself. The `EngineCPUUtilization` metric provides a more precise visibility of the process. You can use it in conjunction with the `CPUUtilization` metric. `CPUUtilization` exposes CPU utilization for the server instance as a whole, including other operating system and management processes. For larger node types with four vCPUs or more, use the `EngineCPUUtilization` metric to monitor and set thresholds for scaling. Note: On an ElastiCache host, background processes monitor the host to provide a managed database experience. These background processes can take up a significant portion of the CPU workload. This is not significant on larger hosts with more than two vCPUs. But it can affect smaller hosts with 2vCPUs or fewer. If you only monitor the `EngineCPUUtilization` metric, you will be unaware of situations where the host is overloaded with both high CPU usage from Valkey or Redis OSS and high CPU usage from the background monitoring processes. Therefore, we recommend monitoring the `CPUUtilization` metric for hosts with two vCPUs or less.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor the CPU utilization of a Redis engine thread within the ElastiCache instance. Common reasons for high engine CPU are long-running commands that consume high CPU, a high number of requests, an increase of new client connection requests in a short time period, and high evictions when the cache doesn’t have enough memory to hold new data. You should consider [Scaling ElastiCache for Redis clusters](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Scaling.html) by adding more nodes or scaling up your instance type.",
+        "threshold": {
+          "staticValue": 90.0,
+          "justification": "Set the threshold to a percentage that reflects the critical engine CPU utilization level for your application. You can benchmark your cluster using your application and expected workload to correlate EngineCPUUtilization and performance as a reference, and then set the threshold accordingly. In most cases, you can set the threshold to about 90% of your available CPU."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "CacheClusterId"
+          }
+        ],
+        "intent": "This alarm is used to detect high CPU utilization of the Redis engine thread. It is useful if you want to monitor the CPU usage of the database engine itself."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "Evictions",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "This metric represents the number of non-expired items that the cache evicted due to memory constraints to allow space for new writes. For ElastiCache Redis, this is derived from the `evicted_keys` statistic at INFO.",
+    "recommendedStatistics": "Average, Maximum, Sum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "GlobalDatastoreReplicationLag",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "This is the lag between the secondary Region's primary node and the primary Region's primary node. For cluster mode enabled Valkey or Redis OSS, the lag indicates the maximum delay among the shards.",
+    "recommendedStatistics": "Maximum, Average, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "IamAuthenticationExpirations",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of expired IAM-authenticated Valkey or Redis OSS connections. You can find more information about [Authenticating with IAM](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html) in the user guide.",
+    "recommendedStatistics": "Sum, Average, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "IamAuthenticationThrottling",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of throttled IAM-authenticated Valkey or Redis OSS AUTH or HELLO requests. You can find more information about [Authenticating with IAM](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html) in the user guide.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "IsMaster",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Indicates whether the node is the primary node of current shard/cluster. The metric can be either 0 (not primary) or 1 (primary).",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "KeyAuthorizationFailures",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of failed attempts by users to access keys they don’t have permission to access. You can find more information about individual authentication failures using the ACL LOG command. We suggest setting an alarm on this to detect unauthorized access attempts.",
+    "recommendedStatistics": "Sum, Average, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "KeysTracked",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of keys being tracked by Valkey or Redis OSS key tracking as a percentage of `tracking-table-max-keys`. Key tracking is used to aid client-side caching and notifies clients when keys are modified.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "MemoryFragmentationRatio",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Indicates the efficiency in the allocation of memory of the Valkey or Redis OSS engine. Certain thresholds signify different behaviors. The recommended value is to have fragmentation above 1.0. This is calculated from the `mem_fragmentation_ratio statistic` of INFO.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Number"
+  },
+  {
+    "metricId": {
+      "metricName": "NewConnections",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of connections that have been accepted by the server during this period. For ElastiCache Redis, this is derived from the `total_connections_received` statistic OSS INFO. Note: If you are using ElastiCache for Redis OSS version 5 or lower, between two and four of the connections reported by this metric are used by ElastiCache to monitor the cluster. However, when using ElastiCache for Redis OSS version 6 or above, the connections used by ElastiCache to monitor the cluster are not included in this metric. For ElastiCache Memcached, this is derived from the memcached total_connections statistic by recording the change in total_connections across a period of time. This will always be at least 1, due to a connection reserved for a ElastiCache.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NumItemsReadFromDisk",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of items retrieved from disk per minute. Supported only for clusters using [Data tiering in ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/data-tiering.html).",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NumItemsWrittenToDisk",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of items written to disk per minute. Supported only for clusters using [Data tiering in ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/data-tiering.html).",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "MasterLinkHealthStatus",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "This status has two values: 0 or 1. The value 0 indicates that data in the ElastiCache primary node is not in sync with Valkey or Redis OSS on EC2. The value of 1 indicates that the data is in sync. To complete the migration, use the [CompleteMigration](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CompleteMigration.html) API operation.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Boolean"
+  },
+  {
+    "metricId": {
+      "metricName": "Reclaimed",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "This metric represents the total number of expired items the cache evicted to allow space for new writes. For ElastiCache Redis, this is derived from the `expired_keys` statistic at INFO.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ReplicationBytes",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "For nodes in a replicated configuration, `ReplicationBytes` reports the number of bytes that the primary is sending to all of its replicas. This metric is representative of the write load on the replication group. This is derived from the `master_repl_offset` statistic at INFO.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ReplicationLag",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "This metric is only applicable for a node running as a read replica. It represents how far behind, in seconds, the replica is in applying changes from the primary node. For Valkey 7.2 and onwards, and Redis OSS 5.0.6 onwards, the lag can be measured in milliseconds.",
+    "recommendedStatistics": "Average, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Seconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor the replication health of your ElastiCache cluster. A high replication lag means that the primary node or the replica can’t keep up the pace of the replication. If your write activity is too high, consider scaling your cluster out by adding more primary nodes, or scaling it up by using a larger node type. Refer to [Scaling ElastiCache for Redis clusters](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Scaling.html) for details. If your read replicas are overloaded by the amount of read requests, consider adding more read replicas.",
+        "threshold": {
+          "justification": "Set the threshold according to your application's requirements and the potential impact of replication lag. You should consider your application's expected write rates and network conditions for the acceptable replication lag."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "CacheClusterId"
+          }
+        ],
+        "intent": "This alarm is used to detect a delay between data updates on the primary node and their synchronization to replica node. It helps to ensure data consistency of a read replica cluster node."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "SaveInProgress",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "This binary metric returns 1 whenever a background save (forked or forkless) is in progress, and 0 otherwise. A background save process is typically used during snapshots and syncs. These operations can cause degraded performance. Using the `SaveInProgress` metric, you can diagnose whether degraded performance was caused by a background save process. This is derived from the `rdb_bgsave_in_progress` statistic at INFO.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Boolean"
+  },
+  {
+    "metricId": {
+      "metricName": "TrafficManagementActive",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Indicates whether ElastiCache for Redis OSS is actively managing traffic by adjusting traffic allocated to incoming commands, monitoring or replication. Traffic is managed when more commands are sent to the node than can be processed by Valkey or Redis OSS and is used to maintain the stability and optimal operation of the engine. Any data points of 1 may indicate that the node is underscaled for the workload being provided. Note: If this metric remains active, evaluate the cluster to decide if scaling up or scaling out is necessary. Related metrics include `NetworkBandwidthOutAllowanceExceeded` and `EngineCPUUtilization`.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Boolean"
+  },
+  {
+    "metricId": {
+      "metricName": "ClusterBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of commands that are cluster-based. This is derived from the `commandstats` statistic by summing all of the commands that act upon a cluster (`cluster slot`, `cluster info`, and so on).",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ClusterBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of cluster-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "EvalBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of commands for eval-based commands. This is derived from the `commandstats` statistic by summing eval, evalsha.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "EvalBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of eval-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "GeoSpatialBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of commands for geospatial-based commands. This is derived from the `commandstats` statistic. It's derived by summing all of the geo type of commands: geoadd, geodist, geohash, geopos, georadius, and georadiusbymember.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "GeoSpatialBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of geospatial-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "GetTypeCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of read-only type commands. This is derived from the `commandstats` statistic by summing all of the read-only type commands (get, hget, scard, lrange, and so on.)",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "GetTypeCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of read commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "HashBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of commands that are hash-based. This is derived from the `commandstats` statistic by summing all of the commands that act upon one or more hashes (hget, hkeys, hvals, hdel, and so on).",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "HashBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of hash-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "HyperLogLogBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of `HyperLogLog`-based commands. This is derived from the `commandstats` statistic by summing all of the pf type of commands (pfadd, pfcount, pfmerge, and so on.).",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "HyperLogLogBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of HyperLogLog-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "JsonBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of JSON commands, including both read and write commands. This is derived from the `commandstats` statistic by summing all JSON commands that act upon JSON keys.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "JsonBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of all JSON commands, including both read and write commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "JsonBasedGetCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of JSON read-only commands. This is derived from the `commandstats` statistic by summing all JSON read commands that act upon JSON keys.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "JsonBasedGetCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of JSON read-only commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "JsonBasedSetCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of JSON write commands. This is derived from the `commandstats` statistic by summing all JSON write commands that act upon JSON keys.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "JsonBasedSetCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of JSON write commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "KeyBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of commands that are key-based. This is derived from the `commandstats` statistic by summing all of the commands that act upon one or more keys across multiple data structures (del, expire, rename, and so on.).",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "KeyBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of key-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ListBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of commands that are list-based. This is derived from the `commandstats` statistic by summing all of the commands that act upon one or more lists (lindex, lrange, lpush, ltrim, and so on).",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ListBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of list-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "NonKeyTypeCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of commands that are not key-based. This is derived from the `commandstats` statistic by summing all of the commands that do not act upon a key, for example, acl, dbsize or info.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NonKeyTypeCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of non-key-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "PubSubBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of commands for pub/sub functionality. This is derived from the `commandstats`statistics by summing all of the commands used for pub/sub functionality: psubscribe, publish, pubsub, punsubscribe, ssubscribe, sunsubscribe, spublish, subscribe, and unsubscribe.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PubSubBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of pub/sub-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "SetBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of commands that are set-based. This is derived from the `commandstats` statistic by summing all of the commands that act upon one or more sets (scard, sdiff, sadd, sunion, and so on).",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SetBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of set-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "SetTypeCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of write types of commands. This is derived from the `commandstats` statistic by summing all of the mutative types of commands that operate on data (set, hset, sadd, lpop, and so on.)",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SetTypeCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of write commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "SortedSetBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of commands that are sorted set-based. This is derived from the `commandstats` statistic by summing all of the commands that act upon one or more sorted sets (zcount, zrange, zrank, zadd, and so on).",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SortedSetBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of sorted-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "StringBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of commands that are string-based. This is derived from the `commandstats` statistic by summing all of the commands that act upon one or more strings (strlen, setex, setrange, and so on).",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "StringBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of string-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "StreamBasedCmds",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of commands that are stream-based. This is derived from the `commandstats` statistic by summing all of the commands that act upon one or more streams data types (xrange, xlen, xadd, xdel, and so on).",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "StreamBasedCmdsLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of stream-based commands.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesReadIntoMemcached",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of bytes that have been read from the network by the cache node.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesUsedForCacheItems",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of bytes used to store cache items.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesWrittenOutFromMemcached",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of bytes that have been written to the network by the cache node.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "CasBadval",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of CAS (check and set) requests the cache has received where the Cas value did not match the Cas value stored.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CasHits",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of Cas requests the cache has received where the requested key was found and the Cas value matched.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CasMisses",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of Cas requests the cache has received where the key requested was not found.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CmdFlush",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of flush commands the cache has received.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CmdGet",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of get commands the cache has received.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CmdSet",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of set commands the cache has received.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DecrHits",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of decrement requests the cache has received where the requested key was found.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DecrMisses",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of decrement requests the cache has received where the requested key was not found.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DeleteHits",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of delete requests the cache has received where the requested key was found.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DeleteMisses",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of delete requests the cache has received where the requested key was not found.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "GetHits",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of get requests the cache has received where the key requested was found.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "GetMisses",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of get requests the cache has received where the key requested was not found.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "IncrHits",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of increment requests the cache has received where the key requested was found.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "IncrMisses",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of increment requests the cache has received where the key requested was not found.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesUsedForHash",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of bytes currently used by hash tables.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "CmdConfigGet",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The cumulative number of config get requests.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CmdConfigSet",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The cumulative number of config set requests.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CmdTouch",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The cumulative number of touch requests.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CurrConfig",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The current number of configurations stored.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "EvictedUnfetched",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of valid items evicted from the least recently used cache (LRU) which were never touched after being set.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ExpiredUnfetched",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of expired items reclaimed from the LRU which were never touched after being set.",
+    "recommendedStatistics": "Average, Sum, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SlabsMoved",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of slab pages that have been moved.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "TouchHits",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of keys that have been touched and were given a new expiration time.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "TouchMisses",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of items that have been touched, but were not found.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NewItems",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The number of new items the cache has stored. This is derived from the memcached total_items statistic by recording the change in total_items across a period of time.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "UnusedMemory",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The amount of memory not used by data. This is derived from the Memcached statistics limit_maxbytes and bytes by subtracting bytes from limit_maxbytes. Because Memcached overhead uses memory in addition to that used by data, UnusedMemory should not be considered to be the amount of memory available for additional data. You may experience evictions even though you still have some unused memory. For more detailed information, see Memcached item memory usage.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkMaxBytesIn",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The maximum per second burst of received bytes within each minute.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkMaxBytesOut",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The maximum per second burst of transmitted bytes within each minute.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkMaxPacketsIn",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The maximum per second burst received packets within each minute.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkMaxPacketsOut",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The maximum per second burst of transmitted packets within each minute.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SuccessfulWriteRequestLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of successful write requests.",
+    "recommendedStatistics": "Average, Sum, Min, Max, Sample Count, any percentile between p0 and p100. The sample count includes only the commands that were successfully executed.",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "SuccessfulReadRequestLatency",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "Latency of successful read requests.",
+    "recommendedStatistics": "Average, Sum, Min, Max, Sample Count, any percentile between p0 and p100. The sample count includes only the commands that were successfully executed.",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ErrorCount",
+      "namespace": "AWS/ElastiCache"
+    },
+    "description": "The total number of failed commands during the specified time period.",
+    "recommendedStatistics": "Average, Sum, Min, Max",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "EndpointHealthyENICount",
+      "namespace": "AWS/Route53Resolver"
+    },
+    "description": "The number of elastic network interfaces in the `OPERATIONAL` status. This means that the Amazon VPC network interfaces for the endpoint (specified by `EndpointId`) are correctly configured and able to pass inbound or outbound DNS queries between your network and Resolver.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "EndpointUnhealthyENICount",
+      "namespace": "AWS/Route53Resolver"
+    },
+    "description": "The number of elastic network interfaces in the `AUTO_RECOVERING` status. This means that the resolver is trying to recover one or more of the Amazon VPC network interfaces that are associated with the endpoint (specified by `EndpointId`). During the recovery process, the endpoint functions with limited capacity and is unable to process DNS queries until it's fully recovered.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "InboundQueryVolume",
+      "namespace": "AWS/Route53Resolver"
+    },
+    "description": "The number of DNS queries forwarded from your network to your VPCs through the specified endpoint or IP address. Each IP address is identified by the IP address ID. You can get this value using the Route 53 console. On the page for the applicable endpoint, in the IP addresses section, see the IP address ID column. You can also get the value programmatically using [ListResolverEndpointIpAddresses](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_ListResolverEndpointIpAddresses.html).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "OutboundQueryVolume",
+      "namespace": "AWS/Route53Resolver"
+    },
+    "description": "For outbound endpoints, the number of DNS queries forwarded from your VPCs to your network through the endpoint specified by `EndpointId`.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "OutboundQueryAggregateVolume",
+      "namespace": "AWS/Route53Resolver"
+    },
+    "description": "The total number of DNS queries forwarded from Amazon VPCs to your network, including the following: 1) The number of DNS queries forwarded from your VPCs to your network through the specified endpoint or IP address. 2) When the current account shares Resolver rules with other accounts, queries from VPCs that are created by other accounts that are forwarded to your network through specified endpoint or IP address. Each IP address is identified by the IP address ID. You can get this value using the Route 53 console. On the page for the applicable endpoint, in the IP addresses section, see the IP address ID column. You can also get the value programmatically using [ListResolverEndpointIpAddresses](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_ListResolverEndpointIpAddresses.html).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "FirewallRuleGroupQueryVolume",
+      "namespace": "AWS/Route53Resolver"
+    },
+    "description": "The number of DNS Firewall queries that match a firewall rule group (specified by `FirewallRuleGroupId`).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "VpcFirewallQueryVolume",
+      "namespace": "AWS/Route53Resolver"
+    },
+    "description": "The number of DNS Firewall queries from a VPC (specified by `VpcId`).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "FirewallRuleGroupVpcQueryVolume",
+      "namespace": "AWS/Route53Resolver"
+    },
+    "description": "The number of DNS Firewall queries from a VPC (specified by `VpcId`) that match a firewall rule group (specified by `FirewallRuleGroupId`).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "FirewallRuleQueryVolume",
+      "namespace": "AWS/Route53Resolver"
+    },
+    "description": "The number of DNS firewall queries that match a firewall domain list (specified by `FirewallDomainListId`) within a firewall rule group (specified by `FirewallRuleGroupId`).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "4XXError",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The number of client-side errors captured in a given period. API Gateway counts modified gateway response status codes as 4XXError errors. The Sum statistic represents this metric, namely, the total count of the 4XXError errors in the given period. The Average statistic represents the 4XXError error rate, namely, the total count of the 4XXError errors divided by the total number of requests during the period. The denominator corresponds to the Count metric.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects a high rate of client-side errors. This can indicate an issue in the authorization or client request parameters. It could also mean that a resource was removed or a client is requesting one that doesn't exist. Consider enabling CloudWatch Logs and checking for any errors that may be causing the 4XX errors. Moreover, consider enabling detailed CloudWatch metrics to view this metric per resource and method and narrow down the source of the errors. Errors could also be caused by exceeding the configured throttling limit. If the responses and logs are reporting high and unexpected rates of 429 errors, follow [this guide](https://repost.aws/knowledge-center/api-gateway-429-limit) to troubleshoot this issue.",
+        "threshold": {
+          "staticValue": 0.05,
+          "justification": "The suggested threshold detects when more than 5% of total requests are getting 4XX errors. However, you can tune the threshold to suit the traffic of the requests as well as acceptable error rates. You can also analyze historical data to determine the acceptable error rate for the application workload and then tune the threshold accordingly. Frequently occurring 4XX errors need to be alarmed on. However, setting a very low value for the threshold can cause the alarm to be too sensitive."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ApiName"
+          },
+          {
+            "name": "Stage"
+          }
+        ],
+        "intent": "This alarm can detect high rates of client-side errors for the API Gateway requests."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "5XXError",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The number of server-side errors captured in a given period. The Sum statistic represents this metric, namely, the total count of the 5XXError errors in the given period. The Average statistic represents the 5XXError error rate, namely, the total count of the 5XXError errors divided by the total number of requests during the period. The denominator corresponds to the Count metric.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect a high rate of server-side errors. This can indicate that there is something wrong on the API backend, the network, or the integration between the API gateway and the backend API. This [documentation](https://repost.aws/knowledge-center/api-gateway-5xx-error) can help you troubleshoot the cause of 5xx errors.",
+        "threshold": {
+          "staticValue": 0.05,
+          "justification": "The suggested threshold detects when more than 5% of total requests are getting 5XX errors. However, you can tune the threshold to suit the traffic of the requests as well as acceptable error rates. you can also analyze historical data to determine the acceptable error rate for the application workload and then tune the threshold accordingly. Frequently occurring 5XX errors need to be alarmed on. However, setting a very low value for the threshold can cause the alarm to be too sensitive."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ApiName"
+          },
+          {
+            "name": "Stage"
+          }
+        ],
+        "intent": "This alarm can detect high rates of server-side errors for the API Gateway requests."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "CacheHitCount",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The number of requests served from the API cache in a given period. The Sum statistic represents this metric, namely, the total count of the cache hits in the given period. The Average statistic represents the cache hit rate, namely, the total count of the cache hits divided by the total number of requests during the period. The denominator corresponds to the Count metric.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CacheMissCount",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The number of requests served from the backend in a given period, when API caching is enabled. The Sum statistic represents this metric, namely, the total count of the cache misses in the given period. The Average statistic represents the cache miss rate, namely, the total count of the cache misses divided by the total number of requests during the period. The denominator corresponds to the Count metric.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "Count",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The total number API requests in a given period. The SampleCount statistic represents this metric.",
+    "recommendedStatistics": "SampleCount",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect low traffic volume for the REST API stage. This can be an indicator of an issue with the application calling the API such as using incorrect endpoints. It could also be an indicator of an issue with the configuration or permissions of the API making it unreachable for clients.",
+        "threshold": {
+          "justification": "Set the threshold based on historical data analysis to determine what the expected baseline request count for your API is. Setting the threshold at a very high value might cause the alarm to be too sensitive at periods of normal and expected low traffic. Conversely, setting it at a very low value might cause the alarm to miss anomalous smaller drops in traffic volume."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "SampleCount",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ApiName"
+          },
+          {
+            "name": "Stage"
+          }
+        ],
+        "intent": "This alarm can detect unexpectedly low traffic volume for the REST API stage. We recommend that you create this alarm if your API receives a predictable and consistent number of requests under normal conditions. If you have detailed CloudWatch metrics enabled and you can predict the normal traffic volume per method and resource, we recommend that you create alternative alarms to have more fine-grained monitoring of traffic volume drops for each resource and method. This alarm is not recommended for APIs that don't expect constant and consistent traffic."
+      },
+      {
+        "alarmDescription": "This alarm helps to detect low traffic volume for the REST API resource and method in the stage. This can indicate an issue with the application calling the API such as using incorrect endpoints. It could also be an indicator of an issue with the configuration or permissions of the API making it unreachable for clients.",
+        "threshold": {
+          "justification": "Set the threshold based on historical data analysis to determine what the expected baseline request count for your API is. Setting the threshold at a very high value might cause the alarm to be too sensitive at periods of normal and expected low traffic. Conversely, setting it at a very low value might cause the alarm to miss anomalous smaller drops in traffic volume."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "SampleCount",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ApiName"
+          },
+          {
+            "name": "Stage"
+          },
+          {
+            "name": "Resource"
+          },
+          {
+            "name": "Method"
+          }
+        ],
+        "intent": "This alarm can detect unexpectedly low traffic volume for the REST API resource and method in the stage. We recommend that you create this alarm if your API receives a predictable and consistent number of requests under normal conditions. This alarm is not recommended for APIs that don't expect constant and consistent traffic."
+      },
+      {
+        "alarmDescription": "This alarm helps to detect low traffic volume for the HTTP API stage. This can indicate an issue with the application calling the API such as using incorrect endpoints. It could also be an indicator of an issue with the configuration or permissions of the API making it unreachable for clients.",
+        "threshold": {
+          "justification": "Set the threshold value based on historical data analysis to determine what the expected baseline request count for your API is. Setting the threshold at a very high value might cause the alarm to be too sensitive at periods of normal and expected low traffic. Conversely, setting it at a very low value might cause the alarm to miss anomalous smaller drops in traffic volume."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "SampleCount",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ApiId"
+          },
+          {
+            "name": "Stage"
+          }
+        ],
+        "intent": "This alarm can detect unexpectedly low traffic volume for the HTTP API stage. We recommend that you create this alarm if your API receives a predictable and consistent number of requests under normal conditions. If you have detailed CloudWatch metrics enabled and you can predict the normal traffic volume per route, we recommend that you create alternative alarms to this in order to have more fine-grained monitoring of traffic volume drops for each route. This alarm is not recommended for APIs that don't expect constant and consistent traffic."
+      },
+      {
+        "alarmDescription": "This alarm helps to detect low traffic volume for the HTTP API route in the stage. This can indicate an issue with the application calling the API such as using incorrect endpoints. It could also indicate an issue with the configuration or permissions of the API making it unreachable for clients.",
+        "threshold": {
+          "justification": "Set the threshold value based on historical data analysis to determine what the expected baseline request count for your API is. Setting the threshold at a very high value might cause the alarm to be too sensitive at periods of normal and expected low traffic. Conversely, setting it at a very low value might cause the alarm to miss anomalous smaller drops in traffic volume."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "SampleCount",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ApiId"
+          },
+          {
+            "name": "Stage"
+          },
+          {
+            "name": "Resource"
+          },
+          {
+            "name": "Method"
+          }
+        ],
+        "intent": "This alarm can detect unexpectedly low traffic volume for the HTTP API route in the stage. We recommend that you create this alarm if your API receives a predictable and consistent number of requests under normal conditions. This alarm is not recommended for APIs that don't expect constant and consistent traffic."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "IntegrationLatency",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The time difference between API Gateway sending the request to the integration and API Gateway receiving the response from the integration. Suppressed for callbacks and mock integrations with WebSocket APIs.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Millisecond",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect if there is high integration latency for the API requests in a stage. You can correlate the `IntegrationLatency` metric value with the corresponding latency metric of your backend such as the `Duration` metric for Lambda integrations. This helps you determine whether the API backend is taking more time to process requests from clients due to performance issues, or if there is some other overhead from initialization or cold start. Additionally, consider enabling CloudWatch Logs for your API and checking the logs for any errors that may be causing the high latency issues. Moreover, consider enabling detailed CloudWatch metrics to get a view of this metric per route, to help you narrow down the source of the integration latency.",
+        "threshold": {
+          "staticValue": 2000.0,
+          "justification": "The suggested threshold value does not work for all the API workloads. However, you can use it as a starting point for the threshold. You can then choose different threshold values based on the workload and acceptable latency, performance, and SLA requirements for the API. If is acceptable for the API to have a higher latency in general, set a higher threshold value to make the alarm less sensitive. However, if the API is expected to provide near real-time responses, set a lower threshold value. You can also analyze historical data to determine the expected baseline latency for the application workload, and then used to tune the threshold value accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "p90",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ApiId"
+          },
+          {
+            "name": "Stage"
+          }
+        ],
+        "intent": "This alarm can detect when the API Gateway requests in a stage have a high integration latency. We recommend this alarm for WebSocket APIs, and we consider it optional for HTTP APIs because they already have separate alarm recommendations for the Latency metric. If you have detailed CloudWatch metrics enabled and you have different integration latency performance requirements per route, we recommend that you create alternative alarms in order to have more fine-grained monitoring of the integration latency for each route."
+      },
+      {
+        "alarmDescription": "This alarm helps to detect if there is high integration latency for the WebSocket API requests for a route in a stage. You can correlate the `IntegrationLatency` metric value with the corresponding latency metric of your backend such as the `Duration` metric for Lambda integrations. This helps you determine whether the API backend is taking more time to process requests from clients due to performance issues or if there is some other overhead from initialization or cold start. Additionally, consider enabling CloudWatch Logs for your API and checking the logs for any errors that may be causing the high latency issues.",
+        "threshold": {
+          "staticValue": 2000.0,
+          "justification": "The suggested threshold value does not work for all the API workloads. However, you can use it as a starting point for the threshold. You can then choose different threshold values based on the workload and acceptable latency, performance, and SLA requirements for the API. If it is acceptable for the API to have a higher latency in general, you can set a higher threshold value to make the alarm less sensitive. However, if the API is expected to provide near real-time responses, set a lower threshold value. You can also analyze historical data to determine the expected baseline latency for the application workload, and then used to tune the threshold value accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "p90",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ApiId"
+          },
+          {
+            "name": "Stage"
+          },
+          {
+            "name": "Route"
+          }
+        ],
+        "intent": "This alarm can detect when the API Gateway requests for a route in a stage have high integration latency."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "Latency",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The time between when API Gateway receives a request from a client and when it returns a response to the client. The latency includes the integration latency and other API Gateway overhead.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Millisecond",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects high latency in a stage. Find the `IntegrationLatency` metric value to check the API backend latency. If the two metrics are mostly aligned, the API backend is the source of higher latency and you should investigate there for issues. Consider also enabling CloudWatch Logs and checking for errors that might be causing the high latency. Moreover, consider enabling detailed CloudWatch metrics to view this metric per resource and method and narrow down the source of the latency. If applicable, refer to the [troubleshooting with Lambda](https://repost.aws/knowledge-center/api-gateway-high-latency-with-lambda) or [troubleshooting for edge-optimized API endpoints](https://repost.aws/knowledge-center/source-latency-requests-api-gateway) guides.",
+        "threshold": {
+          "staticValue": 2500.0,
+          "justification": "The suggested threshold value does not work for all API workloads. However, you can use it as a starting point for the threshold. You can then choose different threshold values based on the workload and acceptable latency, performance, and SLA requirements for the API. If it is acceptable for the API to have a higher latency in general, you can set a higher threshold value to make the alarm less sensitive. However, if the API is expected to provide near real-time responses, set a lower threshold value. You can also analyze historical data to determine what the expected baseline latency is for the application workload and then tune the threshold value accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "p90",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ApiName"
+          },
+          {
+            "name": "Stage"
+          }
+        ],
+        "intent": "This alarm can detect when the API Gateway requests in a stage have high latency. If you have detailed CloudWatch metrics enabled and you have different latency performance requirements for each method and resource, we recommend that you create alternative alarms to have more fine-grained monitoring of the latency for each resource and method."
+      },
+      {
+        "alarmDescription": "This alarm detects high latency for a resource and method in a stage. Find the `IntegrationLatency` metric value to check the API backend latency. If the two metrics are mostly aligned, the API backend is the source of higher latency and you should investigate there for performance issues. Consider also enabling CloudWatch Logs and checking for any errors that might be causing the high latency. You can also refer to the [troubleshooting with Lambda](https://repost.aws/knowledge-center/api-gateway-high-latency-with-lambda) or [troubleshooting for edge-optimized API endpoints](https://repost.aws/knowledge-center/source-latency-requests-api-gateway) guides if applicable.",
+        "threshold": {
+          "staticValue": 2500.0,
+          "justification": "The suggested threshold value does not work for all the API workloads. However, you can use it as a starting point for the threshold. You can then choose different threshold values based on the workload and acceptable latency, performance, and SLA requirements for the API. If it is acceptable for the API to have a higher latency in general, you can set a higher threshold value to make the alarm less sensitive. However, if the API is expected to provide near real-time responses, set a lower threshold value. You can also analyze historical data to determine the expected baseline latency for the application workload and then tune the threshold value accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "p90",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ApiName"
+          },
+          {
+            "name": "Stage"
+          },
+          {
+            "name": "Resource"
+          },
+          {
+            "name": "Method"
+          }
+        ],
+        "intent": "This alarm can detect when the API Gateway requests for a resource and method in a stage have high latency."
+      },
+      {
+        "alarmDescription": "This alarm detects high latency in a stage. Find the `IntegrationLatency` metric value to check the API backend latency. If the two metrics are mostly aligned, the API backend is the source of higher latency and you should investigate there for performance issues. Consider also enabling CloudWatch Logs and checking for any errors that may be causing the high latency. Moreover, consider enabling detailed CloudWatch metrics to view this metric per route and narrow down the source of the latency. You can also refer to the [troubleshooting with Lambda integrations guide](https://repost.aws/knowledge-center/api-gateway-high-latency-with-lambda) if applicable.",
+        "threshold": {
+          "staticValue": 2500.0,
+          "justification": "The suggested threshold value does not work for all the API workloads. However, it can be used as a starting point for the threshold. You can then choose different threshold values based on the workload and acceptable latency, performance and SLA requirements for the API. If it is acceptable for the API to have a higher latency in general, you can set a higher threshold value to make it less sensitive.However, if the API is expected to provide near real-time responses, set a lower threshold value. You can also analyze historical data to determine the expected baseline latency for the application workload and then tune the threshold value accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "p90",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ApiId"
+          },
+          {
+            "name": "Stage"
+          }
+        ],
+        "intent": "This alarm can detect when the API Gateway requests in a stage have high latency. If you have detailed CloudWatch metrics enabled and you have different latency performance requirements per route, we recommend that you create alternative alarms to have more fine-grained monitoring of the latency for each route."
+      },
+      {
+        "alarmDescription": "This alarm detects high latency for a route in a stage. Find the `IntegrationLatency` metric value to check the API backend latency. If the two metrics are mostly aligned, the API backend is the source of higher latency and should be investigated for performance issues. Consider also enabling CloudWatch logs and checking for any errors that might be causing the high latency. You can also refer to the [troubleshooting with Lambda integrations guide](https://repost.aws/knowledge-center/api-gateway-high-latency-with-lambda) if applicable.",
+        "threshold": {
+          "staticValue": 2500.0,
+          "justification": "The suggested threshold value does not work for all the API workloads. However, it can be used as a starting point for the threshold. You can then choose different threshold values based on the workload and acceptable latency, performance, and SLA requirements for the API. If it is acceptable for the API to have a higher latency in general, you can set a higher threshold value to make the alarm less sensitive. However, if the API is expected to provide near real-time responses, set a lower threshold value. You can also analyze historical data to determine the expected baseline latency for the application workload and then tune the threshold value accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "p90",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ApiId"
+          },
+          {
+            "name": "Stage"
+          },
+          {
+            "name": "Resource"
+          },
+          {
+            "name": "Method"
+          }
+        ],
+        "intent": "This alarm is used to detect when the API Gateway requests for a route in a stage have high latency."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "4xx",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The number of client-side errors captured in a given period.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects a high rate of client-side errors. This can indicate an issue in the authorization or client request parameters. It could also mean that a route was removed or a client is requesting one that doesn't exist in the API. Consider enabling CloudWatch Logs and checking for any errors that may be causing the 4xx errors. Moreover, consider enabling detailed CloudWatch metrics to view this metric per route, to help you narrow down the source of the errors. Errors can also be caused by exceeding the configured throttling limit. If the responses and logs are reporting high and unexpected rates of 429 errors, follow [this guide](https://repost.aws/knowledge-center/api-gateway-429-limit) to troubleshoot this issue.",
+        "threshold": {
+          "staticValue": 0.05,
+          "justification": "The suggested threshold detects when more than 5% of total requests are getting 4xx errors. However, you can tune the threshold to suit the traffic of the requests as well as acceptable error rates. You can also analyze historical data to determine the acceptable error rate for the application workload and then tune the threshold accordingly. Frequently occurring 4xx errors need to be alarmed on. However, setting a very low value for the threshold can cause the alarm to be too sensitive."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ApiId"
+          },
+          {
+            "name": "Stage"
+          }
+        ],
+        "intent": "This alarm can detect high rates of client-side errors for the API Gateway requests."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "5xx",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The number of server-side errors captured in a given period.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect a high rate of server-side errors. This can indicate that there is something wrong on the API backend, the network, or the integration between the API gateway and the backend API. This [documentation](https://repost.aws/knowledge-center/api-gateway-5xx-error) can help you troubleshoot the cause for 5xx errors.",
+        "threshold": {
+          "staticValue": 0.05,
+          "justification": "The suggested threshold detects when more than 5% of total requests are getting 5xx errors. However, you can tune the threshold to suit the traffic of the requests as well as acceptable error rates. You can also analyze historical data to determine what the acceptable error rate is for the application workload, and then you can tune the threshold accordingly. Frequently occurring 5xx errors need to be alarmed on. However, setting a very low value for the threshold can cause the alarm to be too sensitive."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ApiId"
+          },
+          {
+            "name": "Stage"
+          }
+        ],
+        "intent": "This alarm can detect high rates of server-side errors for the API Gateway requests."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "DataProcessed",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The amount of data processed in bytes.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ConnectCount",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The number of messages sent to the `$connect` route integration.",
+    "recommendedStatistics": "SampleCount",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "MessageCount",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The number of messages sent to the WebSocket API, either from or to the client.",
+    "recommendedStatistics": "SampleCount",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect low traffic volume for the WebSocket API stage. This can indicate an issue when clients call the API such as using incorrect endpoints, or issues with the backend sending messages to clients. It could also indicate an issue with the configuration or permissions of the API, making it unreachable for clients.",
+        "threshold": {
+          "justification": "Set the threshold value based on historical data analysis to determine what the expected baseline message count for your API is. Setting the threshold to a very high value might cause the alarm to be too sensitive at periods of normal and expected low traffic. Conversely, setting it to a very low value might cause the alarm to miss anomalous smaller drops in traffic volume."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "SampleCount",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ApiId"
+          },
+          {
+            "name": "Stage"
+          }
+        ],
+        "intent": "This alarm can detect unexpectedly low traffic volume for the WebSocket API stage. We recommend that you create this alarm if your API receives and sends a predictable and consistent number of messages under normal conditions. If you have detailed CloudWatch metrics enabled and you can predict the normal traffic volume per route, it is better to create alternative alarms to this one, in order to have more fine-grained monitoring of traffic volume drops for each route. We do not recommend this alarm for APIs that don't expect constant and consistent traffic."
+      },
+      {
+        "alarmDescription": "This alarm helps detect low traffic volume for the WebSocket API route in the stage. This can indicate an issue with the clients calling the API such as using incorrect endpoints, or issues with the backend sending messages to clients. It could also indicate an issue with the configuration or permissions of the API, making it unreachable for clients.",
+        "threshold": {
+          "justification": "Set the threshold based on historical data analysis to determine what the expected baseline message count for your API is. Setting the threshold to a very high value might cause the alarm to be too sensitive at periods of normal and expected low traffic. Conversely, setting it to a very low value might cause the alarm to miss anomalous smaller drops in traffic volume."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "SampleCount",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ApiId"
+          },
+          {
+            "name": "Stage"
+          },
+          {
+            "name": "Route"
+          }
+        ],
+        "intent": "This alarm can detect unexpectedly low traffic volume for the WebSocket API route in the stage. We recommend that you create this alarm if your API receives and sends a predictable and consistent number of messages under normal conditions. We do not recommend this alarm for APIs that don't expect constant and consistent traffic."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "IntegrationError",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The number of requests that return a 4XX/5XX response from the integration.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ClientError",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "The number of requests that have a 4XX response returned by API Gateway before the integration is invoked.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects a high rate of client errors. This can indicate an issue in the authorization or message parameters. It could also mean that a route was removed or a client is requesting one that doesn't exist in the API. Consider enabling CloudWatch Logs and checking for any errors that may be causing the 4xx errors. Moreover, consider enabling detailed CloudWatch metrics to view this metric per route, to help you narrow down the source of the errors. Errors could also be caused by exceeding the configured throttling limit. If the responses and logs are reporting high and unexpected rates of 429 errors, follow [this guide](https://repost.aws/knowledge-center/api-gateway-429-limit) to troubleshoot this issue.",
+        "threshold": {
+          "staticValue": 0.05,
+          "justification": "The suggested threshold detects when more than 5% of total requests are getting 4xx errors. You can tune the threshold to suit the traffic of the requests as well as to suit your acceptable error rates. You can also analyze historical data to determine the acceptable error rate for the application workload, and then tune the threshold accordingly. Frequently occurring 4xx errors need to be alarmed on. However, setting a very low value for the threshold can cause the alarm to be too sensitive."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ApiId"
+          },
+          {
+            "name": "Stage"
+          }
+        ],
+        "intent": "This alarm can detect high rates of client errors for the WebSocket API Gateway messages."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ExecutionError",
+      "namespace": "AWS/ApiGateway"
+    },
+    "description": "Errors that occurred when calling the integration.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect a high rate of execution errors. This can be caused by 5xx errors from your integration, permission issues, or other factors preventing successful invocation of the integration, such as the integration being throttled or deleted. Consider enabling CloudWatch Logs for your API and checking the logs for the type and cause of the errors. Moreover, consider enabling detailed CloudWatch metrics to get a view of this metric per route, to help you narrow down the source of the errors. This [documentation](https://repost.aws/knowledge-center/api-gateway-websocket-error) can also help you troubleshoot the cause of any connection errors.",
+        "threshold": {
+          "staticValue": 0.05,
+          "justification": "The suggested threshold detects when more than 5% of total requests are getting execution errors. You can tune the threshold to suit the traffic of the requests, as well as to suit your acceptable error rates. You can analyze historical data to determine the acceptable error rate for the application workload, and then tune the threshold accordingly. Frequently occurring execution errors need to be alarmed on. However, setting a very low value for the threshold can cause the alarm to be too sensitive."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ApiId"
+          },
+          {
+            "name": "Stage"
+          }
+        ],
+        "intent": "This alarm can detect high rates of execution errors for the WebSocket API Gateway messages."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeReadBytes",
+      "namespace": "AWS/EBS"
+    },
+    "description": "Provides information on the read operations in a specified period of time. The Sum statistic reports the total number of bytes transferred during the period. The Average statistic reports the average size of each read operation during the period, except on volumes attached to a Nitro instance, where the average represents the average over the specified period. The SampleCount statistic reports the total numberof read operations during the period, except on volumes attached to a Nitro-based instance, where the sample count represents the number of data points used in the statistical calculation. Note: For Xen instances, data is reported only when there is read activity on the volume.",
+    "recommendedStatistics": "Average, Sum, SampleCount, Minimum | Maximum — only for volumes attached to Nitro-based instances",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeWriteBytes",
+      "namespace": "AWS/EBS"
+    },
+    "description": "Provides information on the write operations in a specified period of time. The Sum statistic reports the total number of bytes transferred during the period. The Average statistic reports the average size of each write operation during the period, except on volumes attached to a Nitro-based instance, where the average represents the average over the specified period. The SampleCount statistic reports the total number of write operations during the period, except on volumes attached to a Nitro-based instance, where the sample count represents the number of data points used in the statistical calculation. Note: For Xen instances, data is reported only when there is write activity on the volume.",
+    "recommendedStatistics": "Average, Sum, SampleCount, Minimum | Maximum — only for volumes attached to Nitro-based instances",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeReadOps",
+      "namespace": "AWS/EBS"
+    },
+    "description": "The total number of read operations in a specified period of time. Read operations are counted on completion. To calculate the average read operations per second (read IOPS) for the period, divide the total read operations in the period by the number of seconds in that period. To monitor EBS storage latency, you can create metric math alarm by following [Monitoring and understanding Amazon EBS performance using Amazon CloudWatch](https://aws.amazon.com/blogs/storage/valuable-tips-for-monitoring-and-understanding-amazon-ebs-performance-using-amazon-cloudwatch).",
+    "recommendedStatistics": "Average, Sum, Minimum | Maximum — only for volumes attached to Nitro-based instances",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeWriteOps",
+      "namespace": "AWS/EBS"
+    },
+    "description": "The total number of write operations in a specified period of time. Write operations are counted on completion. To calculate the average write operations per second (write IOPS) for the period, divide the total write operations in the period by the number of seconds in that period. To monitor EBS storage latency, you can create metric math alarm by following [Monitoring and understanding Amazon EBS performance using Amazon CloudWatch](https://aws.amazon.com/blogs/storage/valuable-tips-for-monitoring-and-understanding-amazon-ebs-performance-using-amazon-cloudwatch).",
+    "recommendedStatistics": "Average, Sum, Minimum | Maximum — only for volumes attached to Nitro-based instances",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeTotalReadTime",
+      "namespace": "AWS/EBS"
+    },
+    "description": "The total number of seconds spent by all read operations that completed in a specified period of time. If multiple requests are submitted at the same time, this total could be greater than the length of the period. For example, for a period of 1 minutes (60 seconds): if 150 operations completed during that period, and each operation took 1 second, the value would be 150 seconds. Note: Not supported with Multi-Attach enabled volumes. For Xen instances, data is reported only when there is read activity on the volume. To monitor EBS storage latency, you can create metric math alarm by following [Monitoring and understanding Amazon EBS performance using Amazon CloudWatch](https://aws.amazon.com/blogs/storage/valuable-tips-for-monitoring-and-understanding-amazon-ebs-performance-using-amazon-cloudwatch).",
+    "recommendedStatistics": "Average — not relevant for volumes attached to Nitro-based instances, Sum, Minimum | Maximum — only for volumes attached to Nitro-based instances",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeTotalWriteTime",
+      "namespace": "AWS/EBS"
+    },
+    "description": "The total number of seconds spent by all write operations that completed in a specified period of time. If multiple requests are submitted at the same time, this total could be greater than the length of the period. For example, for a period of 1 minute (60 seconds): if 150 operations completed during that period, and each operation took 1 second, the value would be 150 seconds. Note: Not supported with Multi-Attach enabled volumes. For Xen instances, data is reported only when there is write activity on the volume. To monitor EBS storage latency, you can create metric math alarm by following [Monitoring and understanding Amazon EBS performance using Amazon CloudWatch](https://aws.amazon.com/blogs/storage/valuable-tips-for-monitoring-and-understanding-amazon-ebs-performance-using-amazon-cloudwatch).",
+    "recommendedStatistics": "Average — not relevant for volumes attached to Nitro-based instances, Sum, Minimum | Maximum — only for volumes attached to Nitro-based instances",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeIdleTime",
+      "namespace": "AWS/EBS"
+    },
+    "description": "The total number of seconds in a specified period of time when no read or write operations were submitted. Note: Not supported with Multi-Attach enabled volumes.",
+    "recommendedStatistics": "Average — not relevant for volumes attached to Nitro-based instances, Sum, Minimum | Maximum — only for volumes attached to Nitro-based instances",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeQueueLength",
+      "namespace": "AWS/EBS"
+    },
+    "description": "The number of read and write operation requests waiting to be completed in a specified period of time.",
+    "recommendedStatistics": "Average, Sum — not relevant for volumes attached to Nitro instances, Minimum | Maximum — only for volumes attached to Nitro instances",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeThroughputPercentage",
+      "namespace": "AWS/EBS"
+    },
+    "description": "The percentage of I/O operations per second (IOPS) delivered of the total IOPS provisioned for an Amazon EBS volume. Provisioned IOPS SSD volumes deliver their provisioned performance 99.9 percent of the time. During a write, if there are no other pending I/O requests in a minute, the metric value will be 100 percent. Also, a volume's I/O performance may become degraded temporarily due to an action you have taken (for example, creating a snapshot of a volume during peak usage, running the volume on a non-EBS-optimized instance, or accessing data on the volume for the first time). Note: Provisioned IOPS SSD volumes only. Not supported with Multi-Attach enabled volumes.",
+    "recommendedStatistics": "Average, Minimum | Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeConsumedReadWriteOps",
+      "namespace": "AWS/EBS"
+    },
+    "description": "The total amount of read and write operations (normalized to 256K capacity units) consumed in a specified period of time. I/O operations that are smaller than 256K each count as 1 consumed IOPS. I/O operations that are larger than 256K are counted in 256K capacity units. For example, a 1024K I/O would count as 4 consumed IOPS. Note: Provisioned IOPS SSD volumes only.",
+    "recommendedStatistics": "Average, Sum, Minimum | Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BurstBalance",
+      "namespace": "AWS/EBS"
+    },
+    "description": "Provides information about the percentage of I/O credits (for `gp2`) or throughput credits (for `st1` and `sc1`) remaining in the burst bucket. Data is reported to CloudWatch only when the volume is active. If the volume is not attached, no data is reported. If the baseline performance of the volume exceeds the maximum burst performance, credits are never spent. If the volume is attached to an instance built on the Nitro System, the burst balance is not reported. For other instances, the reported burst balance is 100%. For more information, see [gp2 volume performance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html#gp2-performance). Note: `gp2`, `st1`, and `sc1` volumes only.",
+    "recommendedStatistics": "Average, Sum — not relevant for volumes attached to Nitro instances. Minimum | Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "FastSnapshotRestoreCreditsBucketSize",
+      "namespace": "AWS/EBS"
+    },
+    "description": "The maximum number of volume create credits that can be accumulated. This metric is reported per snapshot per Availability Zone.",
+    "recommendedStatistics": "Average, Minimum | Maximum, Note The most meaningful statistic is Average. The results for the Minimum and Maximum statistics are the same as for Average and could be used instead.",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "FastSnapshotRestoreCreditsBalance",
+      "namespace": "AWS/EBS"
+    },
+    "description": "The number of volume create credits available. This metric is reported per snapshot per Availability Zone.",
+    "recommendedStatistics": "Average, Minimum | Maximum, Note The most meaningful statistic is Average. The results for the Minimum and Maximum statistics are the same as for Average and could be used instead.",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeStalledIOCheck",
+      "namespace": "AWS/EBS"
+    },
+    "description": "Reports whether a volume has passed or failed a stalled IO check in the last minute.This metric can be either `0` (passed) or `1` (failed). For more information, see [Monitor I/O characteristics using CloudWatch](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html#ebs-io-metrics). Note: For Nitro instances only. Not published for volumes attached to Amazon ECS and AWS Fargate tasks.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "None",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you monitor the IO performance of your EBS volumes. This check detects underlying issues with the Amazon EBS infrastructure, such as hardware or software issues on the storage subsystems underlying the EBS volumes, hardware issues on the physical host that impact the reachability of the EBS volumes from your EC2 instance, and can detect connectivity issues between the instance and the EBS volumes. If the Stalled IO Check fails, you can either wait for AWS to resolve the issue, or you can take action such as replacing the affected volume or stopping and restarting the instance to which the volume is attached. In most cases, when this metric fails, EBS will automatically diagnose and recover your volume within a few minutes.",
+        "threshold": {
+          "staticValue": 1.0,
+          "justification": "When a status check fails, the value of this metric is 1. The threshold is set so that whenever the status check fails, the alarm is in ALARM state."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "VolumeId"
+          },
+          {
+            "name": "InstanceId"
+          }
+        ],
+        "intent": "This alarm can detect the status of your EBS volumes to determine when these volumes are impaired and can not complete I/O operations."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeAvgReadLatency",
+      "namespace": "AWS/EBS"
+    },
+    "description": "The average time taken to complete read operations in a minute. Use this metric to monitor the average I/O latency of the EBS volumes attached to your Amazon EC2 instances. The average is calculated based on I/O operations that completed in the last minute. If no operations completed within the last minute, then value for the metric is zero. For Multi-Attach enabled volumes, use the `InstanceID` dimension to view average latency for a specific volume-instance attachement. Note: Supported for all volume types attached to Nitro instances. Not published for volumes attached to Amazon ECS and AWS Fargate tasks.",
+    "recommendedStatistics": "Minimum | Maximum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeAvgWriteLatency",
+      "namespace": "AWS/EBS"
+    },
+    "description": "The average time taken to complete write operations in a minute. Use this metric to monitor the average I/O latency of the EBS volumes attached to your Amazon EC2 instances. The average is calculated based on I/O operations that completed in the last minute. If no operations completed within the last minute, then value for the metric is zero. For Multi-Attach enabled volumes, use the `InstanceID` dimension to view average latency for a specific volume-instance attachement. Note: Supported for all volume types attached to Nitro instances. Not published for volumes attached to Amazon ECS and AWS Fargate tasks.",
+    "recommendedStatistics": "Minimum | Maximum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeIOPSExceededCheck",
+      "namespace": "AWS/EBS"
+    },
+    "description": "Reports whether an application consistently attempted to drive IOPS that exceeds the volume's provisioned IOPS performance within the last minute. This metric can be either `0` (provisioned IOPS not exceeded) or `1` (provisioned IOPS exceeded). For more information, see [Monitor I/O characteristics using CloudWatch](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html#ebs-io-metrics). Note: Supported for all volume types, except magnetic (`standard`), attached to Nitro instances. Not supported with Multi-Attach enabled volumes. Not published for volumes attached to Amazon ECS and AWS Fargate tasks.",
+    "recommendedStatistics": "Sum, Average, Minimum | Maximum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeThroughputExceededCheck",
+      "namespace": "AWS/EBS"
+    },
+    "description": "Reports whether an application consistently attempted to drive throughput that exceeds the volume's provisioned throughput performance within the last minute. This metric can be either `0` (provisioned throughput not exceeded) or `1` (provisioned throughput exceeded).For more information, see [Monitor I/O characteristics using CloudWatch](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html#ebs-io-metrics). Note: Supported for all volume types, except magnetic (`standard`), attached to Nitro instances. Not supported with Multi-Attach enabled volumes. Not published for volumes attached to Amazon ECS and AWS Fargate tasks.",
+    "recommendedStatistics": "Sum, Average, Minimum | Maximum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "GetRecords.Bytes",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of bytes retrieved from the Kinesis stream, measured over the specified time period. Minimum, Maximum, and Average statistics represent the bytes in a single `GetRecords` operation for the stream in the specified time period. Shard-level metric name: `OutgoingBytes`.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "GetRecords.IteratorAge",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "This metric is no longer used. Use `GetRecords.IteratorAgeMilliseconds`.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Samples",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "GetRecords.IteratorAgeMilliseconds",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The age of the last record in all `GetRecords` calls made against a Kinesis stream, measured over the specified time period. Age is the difference between the current time and when the last record of the `GetRecords` call was written to the stream. The Minimum and Maximum statistics can be used to track the progress of Kinesis consumer applications. A value of zero indicates that the records being read are completely caught up with the stream. Shard-level metric name: `IteratorAgeMilliseconds`.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Samples",
+    "unitInfo": "Milliseconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm can detect if iterator maximum age is too high. For real-time data processing applications, configure data retention according to tolerance of the delay. This is usually within minutes. For applications that process historic data, use this metric to monitor catchup speed. A quick solution to stop data loss is to increase the retention period while you troubleshoot the issue. You can also increase the number of workers processing records in your consumer application. The most common causes for gradual iterator age increase are insufficient physical resources or record processing logic that has not scaled with an increase in stream throughput. See [link](https://repost.aws/knowledge-center/kinesis-data-streams-iteratorage-metric) for more details.",
+        "threshold": {
+          "justification": "The recommended threshold value for this alarm is highly dependent on the stream retention period and tolerance of processing delay for the records. Review your requirements and analyze historical trends, and then set the threshold to the number of milliseconds that represents a critical processing delay. If an iterator's age passes 50% of the retention period (by default, 24 hours, configurable up to 365 days), there is a risk for data loss because of record expiration. You can monitor the metric to make sure that none of your shards ever approach this limit."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "StreamName"
+          }
+        ],
+        "intent": "This alarm is used to detect if data in your stream is going to expire because of being preserved too long or because record processing is too slow. It helps you avoid data loss after reaching 100% of the stream retention time."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "GetRecords.Latency",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The time taken per `GetRecords` operation, measured over the specified time period.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "GetRecords.Records",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of records retrieved from the shard, measured over the specified time period. Minimum, Maximum, and Average statistics represent the records in a single `GetRecords` operation for the stream in the specified time period. Shard-level metric name: `OutgoingRecords`.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "GetRecords.Success",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of successful `GetRecords` operations per stream, measured over the specified time period.",
+    "recommendedStatistics": "Average, Sum, Samples",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This metric increments whenever your consumers successfully read data from your stream. `GetRecords` doesn't return any data when it throws an exception. The most common exception is `ProvisionedThroughputExceededException` because request rate for the stream is too high, or because available throughput is already served for the given second. Reduce the frequency or size of your requests. For more information, see Streams [Limits](https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html) in the Amazon Kinesis Data Streams Developer Guide, and [Error Retries and Exponential Backoff in AWS](https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html).",
+        "threshold": {
+          "justification": "Depending on the importance of retrieving records from the stream, set the threshold based on your application’s tolerance for failed records. The threshold should be the corresponding percentage of successful operations. You can use historical GetRecords metric data as reference for the acceptable failure rate. You should also consider retries when setting the threshold because failed records can be retried. This helps to prevent transient spikes from triggering unnecessary alerts."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "StreamName"
+          }
+        ],
+        "intent": "This alarm can detect if the retrieval of records from the stream by consumers is failing. By setting an alarm on this metric, you can proactively detect any issues with data consumption, such as increased error rates or a decline in successful retrievals. This allows you to take timely actions to resolve potential problems and maintain a smooth data processing pipeline."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "IncomingBytes",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of bytes successfully put to the Kinesis stream / shard over the specified time period. This metric includes bytes from `PutRecord` and `PutRecords` operations. Minimum, Maximum, and Average statistics represent the bytes in a single put operation for the stream / shard in the specified time period. If metric dimensions include ShardId, it's a shard-level metric.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "IncomingRecords",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of records successfully put to the Kinesis stream / shard over the specified time period. This metric includes record counts from `PutRecord` and `PutRecords` operations. Minimum, Maximum, and Average statistics represent the records in a single put operation for the stream / shard in the specified time period. If metric dimensions include ShardId, it's a shard-level metric.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PutRecord.Bytes",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of bytes put to the Kinesis stream using the `PutRecord` operation over the specified time period.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "PutRecord.Latency",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The time taken per `PutRecord` operation, measured over the specified time period.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "PutRecord.Success",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of successful `PutRecord` operations per Kinesis stream, measured over the specified time period. Average reflects the percentage of successful writes to a stream.",
+    "recommendedStatistics": "Average, Sum, Samples",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects when the number of failed `PutRecord` operations breaches the threshold. Investigate the data producer logs to find the root causes of the failures. The most common reason is insufficient provisioned throughput on the shard that caused the `ProvisionedThroughputExceededException`. It happens because the request rate for the stream is too high, or the throughput attempted to be ingested into the shard is too high. Reduce the frequency or size of your requests. For more information, see Streams [Limits](https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html) and [Error Retries and Exponential Backoff in AWS](https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html).",
+        "threshold": {
+          "justification": "Depending on the importance of data ingestion and processing to your service, set the threshold based on your application’s tolerance for failed records. The threshold should be the corresponding percentage of successful operations. You can use historical PutRecord metric data as reference for the acceptable failure rate. You should also consider retries when setting the threshold because failed records can be retried."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "StreamName"
+          }
+        ],
+        "intent": "This alarm can detect if ingestion of records into the stream is failing. It helps you identify issues in writing data to the stream. By setting an alarm on this metric, you can proactively detect any issues of producers in publishing data to the stream, such as increased error rates or a decrease in successful records being published. This enables you to take timely actions to address potential problems and maintain a reliable data ingestion process."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "PutRecords.Bytes",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of bytes put to the Kinesis stream using the `PutRecords` operation over the specified time period.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "PutRecords.Latency",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The time taken per `PutRecords` operation, measured over the specified time period.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "PutRecords.Records",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "This metric is deprecated. Use `PutRecords.SuccessfulRecords`.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PutRecords.Success",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of `PutRecords` operations where at least one record succeeded, per Kinesis stream, measured over the specified time period.",
+    "recommendedStatistics": "Average, Sum, Samples",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PutRecords.TotalRecords",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The total number of records sent in a `PutRecords` operation per Kinesis data stream, measured over the specified time period.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PutRecords.SuccessfulRecords",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of successful records in a `PutRecords` operation per Kinesis data stream, measured over the specified time period.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PutRecords.FailedRecords",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of records rejected due to internal failures in a `PutRecords` operation per Kinesis data stream, measured over the specified time period. Occasional internal failures are to be expected and should be retried.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects when the number of failed `PutRecords` exceeds the threshold. Kinesis Data Streams attempts to process all records in each `PutRecords` request, but a single record failure does not stop the processing of subsequent records. The main reason for these failures is exceeding the throughput of a stream or an individual shard. Common causes are traffic spikes and network latencies that cause records to arrive to the stream unevenly. You should detect unsuccessfully processed records and retry them in a subsequent call. Refer to [Handling Failures When Using PutRecords](https://docs.aws.amazon.com/streams/latest/dev/developing-producers-with-sdk.html) for more details.",
+        "threshold": {
+          "justification": "Set the threshold to the number of failed records reflecting the tolerance of the the application for failed records. You can use historical data as reference for the acceptable failure value. You should also consider retries when setting the threshold because failed records can be retried in subsequent PutRecords calls."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "StreamName"
+          }
+        ],
+        "intent": "This alarm can detect consistent failures when using batch operation to put records to your stream. By setting an alarm on this metric, you can proactively detect an increase in failed records, enabling you to take timely actions to address the underlying problems and ensure a smooth and reliable data ingestion process."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "PutRecords.ThrottledRecords",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of records rejected due to throttling in a `PutRecords` operation per Kinesis data stream, measured over the specified time period.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadProvisionedThroughputExceeded",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of `GetRecords` calls throttled for the stream / shard over the specified time period. This metric covers all dimensions of the following limits: 5 reads per shard per second or 2 MB per second per shard. The most commonly used statistic for this metric is Average. When the Minimum statistic has a value of 1, all records were throttled for the stream / shard during the specified time period. When the Maximum statistic has a value of 0 (zero), no records were throttled for the stream / shard during the specified time period. If metric dimensions include ShardId, it's a shard-level metric.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "The alarm tracks the number of records that result in read throughput capacity throttling. If you find that you are being consistently throttled, you should consider adding more shards to your stream to increase your provisioned read throughput. If there is more than one consumer application running on the stream, and they share the `GetRecords` limit, we recommend that you register new consumer applications via Enhanced Fan-Out. If adding more shards does not lower the number of throttles, you may have a “hot” shard that is being read from more than other shards are. Enable enhanced monitoring, find the “hot” shard, and split it.",
+        "threshold": {
+          "justification": "Usually throttled requests can be retried and hence setting the threshold to zero makes the alarm too sensitive. However, consistent throttling can impact reading from the stream and should trigger the alarm. Set the threshold to a percentage according to the throttled requests for the application and retry configurations."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "StreamName"
+          }
+        ],
+        "intent": "This alarm can detect if consumers are throttled when they exceed your provisioned read throughput (determined by the number of shards you have). In that case, you won’t be able to read from the stream, and the stream can start backing up."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "SubscribeToShard.RateExceeded",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "This metric is emitted when a new subscription attempt fails because there already is an active subscription by the same consumer or if you exceed the number of calls per second allowed for this operation.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SubscribeToShard.Success",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "This metric records whether the SubscribeToShard subscription was successfully established. The subscription only lives for at most 5 minutes. Therefore, this metric is emitted at least once every 5 minutes.",
+    "recommendedStatistics": "Average, Sum, Samples",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SubscribeToShardEvent.Bytes",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of bytes received from the shard, measured over the specified time period. Minimum, Maximum, and Average statistics represent the bytes published in a single event for the specified time period. Shard-level metric name: `OutgoingBytes`.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "SubscribeToShardEvent.MillisBehindLatest",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of milliseconds the read records are from the tip of the stream, indicating how far behind current time the consumer is.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Samples",
+    "unitInfo": "Milliseconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects when the delay of record processing in the application breaches the threshold. Transient problems such as API operation failures to a downstream application can cause a sudden increase in the metric. You should investigate if they consistently happen. A common cause is the consumer is not processing records fast enough because of insuﬃcient physical resources or record processing logic that has not scaled with an increase in stream throughput. Blocking calls in critical path is often the cause of slowdowns in record processing. You can increase your parallelism by increasing the number of shards. You should also confirm underlying processing nodes have sufficient physical resources during peak demand.",
+        "threshold": {
+          "justification": "The recommended threshold value for this alarm is highly dependent on the delay that your application can tolerate. Review your application's requirements and analyze historical trends, and then select a threshold accordingly. When the SubscribeToShard call succeeds, your consumer starts receiving SubscribeToShardEvent events over the persistent connection for up to 5 minutes, after which time you need to call SubscribeToShard again to renew the subscription if you want to continue to receive records."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "StreamName"
+          },
+          {
+            "name": "ConsumerName"
+          }
+        ],
+        "intent": "This alarm can detect delay in the subscription to shard event of the stream. This indicates a processing lag and can help identify potential issues with the consumer application's performance or the overall stream's health. When the processing lag becomes significant, you should investigate and address any bottlenecks or consumer application inefficiencies to ensure real-time data processing and minimize data backlog."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "SubscribeToShardEvent.Records",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of records received from the shard, measured over the specified time period. Minimum, Maximum, and Average statistics represent the records in a single event for the specified time period. Shard-level metric name: `OutgoingRecords`.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SubscribeToShardEvent.Success",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "This metric is emitted every time an event is published successfully. It is only emitted when there's an active subscription.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteProvisionedThroughputExceeded",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of records rejected due to throttling for the stream / shard over the specified time period. This metric includes throttling from `PutRecord` and `PutRecords` operations. It covers all dimensions of the following limits: 1,000 records per second per shard or 1 MB per second per shard. The most commonly used statistic for this metric is Average. When the Minimum statistic has a non-zero value, records were being throttled for the stream / shard during the specified time period. When the Maximum statistic has a value of 0 (zero), no records were being throttled for the stream /shard during the specified time period. If metric dimensions include ShardId, it's a shard-level metric.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects when the number of records resulting in write throughput capacity throttling reached the threshold. When your producers exceed your provisioned write throughput (determined by the number of shards you have), they are throttled and you won’t be able to put records to the stream. To address consistent throttling, you should consider adding shards to your stream. This raises your provisioned write throughput and prevents future throttling. You should also consider partition key choice when ingesting records. Random partition key is preferred because it spreads records evenly across the shards of the stream, whenever possible.",
+        "threshold": {
+          "justification": "Usually throttled requests can be retried, so setting the threshold to zero makes the alarm too sensitive. However, consistent throttling can impact writing to the stream, and you should set the alarm threshold to detect this. Set the threshold to a percentage according to the throttled requests for the application and retry configurations."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "StreamName"
+          }
+        ],
+        "intent": "This alarm can detect if your producers are being rejected for writing records because of throttling of the stream or shard. If your stream is in Provisioned mode, then setting this alarm helps you proactively take actions when the data stream reaches its limits, allowing you to optimize the provisioned capacity or take appropriate scaling actions to avoid data loss and maintain smooth data processing."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "IteratorAgeMilliseconds",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The age of the last record in all `GetRecords` calls made against a shard, measured over the specified time period. Age is the difference between the current time and when the last record of the `GetRecords` call was written to the stream. The Minimum and Maximum statistics can be used to track the progress of Kinesis consumer applications. A value of 0 (zero) indicates that the records being read are completely caught up with the stream. Stream-level metric name: `GetRecords.IteratorAgeMilliseconds`.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Samples",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "OutgoingBytes",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of bytes retrieved from the shard, measured over the specified time period. Minimum, Maximum, and Average statistics represent the bytes returned in a single `GetRecords` operation or published in a single `SubscribeToShard` event for the shard in the specified time period. Stream-level metric name: `GetRecords.Bytes`.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "OutgoingRecords",
+      "namespace": "AWS/Kinesis"
+    },
+    "description": "The number of records retrieved from the shard, measured over the specified time period. Minimum, Maximum, and Average statistics represent the records returned in a single `GetRecords` operation or published in a single `SubscribeToShard` event for the shard in the specified time period. Stream-level metric name: `GetRecords.Records`.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, Samples",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AccountMaxReads",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The maximum number of read capacity units that can be used by an account. This limit doesn't apply to on-demand tables or global secondary indexes.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AccountMaxTableLevelReads",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The maximum number of read capacity units that can be used by a table or global secondary index of an account. For on-demand tables, this limit caps the maximum read request units a table or a global secondary index can use.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AccountMaxTableLevelWrites",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The maximum number of write capacity units that can be used by a table or global secondary index of an account. For on-demand tables, this limit caps the maximum write request units a table or a global secondary index can use.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AccountMaxWrites",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The maximum number of write capacity units that can be used by an account. This limit doesn't apply to on-demand tables or global secondary indexes.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AccountProvisionedReadCapacityUtilization",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The percentage of provisioned read capacity units utilized by an account.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects if the account’s read capacity is reaching its provisioned limit. You can raise the account quota for read capacity utilization if this occurs. You can view your current quotas for read capacity units and request increases using [Service Quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html).",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to 80%, so that action (such as raising the account limits) can be taken before it reaches full capacity to avoid throttling."
+        },
+        "period": 300,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 2,
+        "datapointsToAlarm": 2,
+        "treatMissingData": "missing",
+        "dimensions": [],
+        "intent": "The alarm can detect if the account’s read capacity utilization is approaching its provisioned read capacity utilization. If the utilization reaches its maximum limit, DynamoDB starts to throttle read requests."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "AccountProvisionedWriteCapacityUtilization",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The percentage of provisioned write capacity units utilized by an account.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects if the account’s write capacity is reaching its provisioned limit. You can raise the account quota for write capacity utilization if this occurs. You can view your current quotas for write capacity units and request increases using [Service Quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html).",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to 80%, so that the action (such as raising the account limits) can be taken before it reaches full capacity to avoid throttling."
+        },
+        "period": 300,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 2,
+        "datapointsToAlarm": 2,
+        "treatMissingData": "missing",
+        "dimensions": [],
+        "intent": "This alarm can detect if the account’s write capacity utilization is approaching its provisioned write capacity utilization. If the utilization reaches its maximum limit, DynamoDB starts to throttle write requests."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "AgeOfOldestUnreplicatedRecord",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The elapsed time since a record yet to be replicated to the Kinesis data stream first appeared in the DynamoDB table.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Milliseconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects the delay in replication to a Kinesis data stream. Under normal operation, `AgeOfOldestUnreplicatedRecord` should be only milliseconds. This number grows based on unsuccessful replication attempts caused by customer-controlled configuration choices. Customer-controlled configuration examples that lead to unsuccessful replication attempts are an under-provisioned Kinesis data stream capacity that leads to excessive throttling. or a manual update to the Kinesis data stream’s access policies that prevents DynamoDB from adding data to the data stream. To keep this metric as low as possible, you need to ensure the right provisioning of Kinesis data stream capacity and make sure that DynamoDB’s permissions are unchanged.",
+        "threshold": {
+          "justification": "Set the threshold according to the desired replication delay measured in milliseconds. This value depends on your workload's requirements and expected performance."
+        },
+        "period": 300,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "TableName"
+          },
+          {
+            "name": "DelegatedOperation"
+          }
+        ],
+        "intent": "This alarm can monitor unsuccessful replication attempts and the resulting delay in replication to the Kinesis data stream."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ConditionalCheckFailedRequests",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of failed attempts to perform conditional writes. The `PutItem`, `UpdateItem`, and `DeleteItem` operations let you provide a logical condition that must evaluate to true before the operation can proceed. If this condition evaluates to false, `ConditionalCheckFailedRequests` is incremented by one. `ConditionalCheckFailedRequests` is also incremented by one for PartiQL Update and Delete statements where a logical condition is provided and that condition evaluates to false. Note: A failed conditional write will result in an HTTP 400 error (Bad Request). These events are reflected in the `ConditionalCheckFailedRequests` metric, but not in the `UserErrors` metric.",
+    "recommendedStatistics": "Maximum, Minimum, Average, SampleCount, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ConsumedChangeDataCaptureUnits",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of consumed change data capture units.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ConsumedReadCapacityUnits",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of read capacity units consumed over the specified time period for both provisioned and on-demand capacity, so you can track how much of your throughput is used. You can retrieve the total consumed read capacity for a table and all of its global secondary indexes, or for a particular global secondary index. For more information, see [Read/Write Capacity Mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html). The `TableName` dimension returns the `ConsumedReadCapacityUnits` for the table, but not for any global secondary indexes. To view `ConsumedReadCapacityUnits` for a global secondary index, you must specify both `TableName` and `GlobalSecondaryIndexName`. Note: This means that short, intense spikes in capacity consumption lasting just a second may not be accurately reflected in the CloudWatch graph, potentially leading to a lower apparent consumption rate for that minute. Use the Sum statistic to calculate the consumed throughput. For example, get the Sum value over a span of one minute, and divide it by the number of seconds in a minute (60) to calculate the average `ConsumedReadCapacityUnits` per second. You can compare the calculated value to the provisioned throughput value that you provide DynamoDB. Note: The Average value is influenced by periods of inactivity where the sample value will be zero. Note: The SampleCount value is influenced by periods of inactivity where the sample value will be zero.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, SampleCount (The number of read requests to DynamoDB)",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ConsumedWriteCapacityUnits",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of write capacity units consumed over the specified time period for both provisioned and on-demand capacity, so you can track how much of your throughput is used. You can retrieve the total consumed write capacity for a table and all of its global secondary indexes, or for a particular global secondary index. For more information, see [Read/Write Capacity Mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html). The `TableName` dimension returns the `ConsumedWriteCapacityUnits` for the table, but not for any global secondary indexes. To view `ConsumedWriteCapacityUnits` for a global secondary index, you must specify both `TableName` and `GlobalSecondaryIndexName`. Note: Use the Sum statistic to calculate the consumed throughput. For example, get the Sum value over a span of one minute, and divide it by the number of seconds in a minute (60) to calculate the average `ConsumedWriteCapacityUnits` per second (recognizing that this average doesn't highlight any large but brief spikes in write activity that occurred during that minute). You can compare the calculated value to the provisioned throughput value that you provide DynamoDB. Note: The Average value is influenced by periods of inactivity where the sample value will be zero. Note: The SampleCount value is influenced by periods of inactivity where the sample value will be zero.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, SampleCount (The number of write requests to DynamoDB)",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "FailedToReplicateRecordCount",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of records that DynamoDB failed to replicate to your Kinesis data stream.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects the number of records that DynamoDB failed to replicate to your Kinesis data stream. Certain items larger than 34 KB might expand in size to change data records that are larger than the 1 MB item size limit of Kinesis Data Streams. This size expansion occurs when these larger than 34 KB items include a large number of Boolean or empty attribute values. Boolean and empty attribute values are stored as 1 byte in DynamoDB, but expand up to 5 bytes when they’re serialized using standard JSON for Kinesis Data Streams replication. DynamoDB can’t replicate such change records to your Kinesis data stream. DynamoDB skips these change data records, and automatically continues replicating subsequent records.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "Set the threshold to 0 to detect any records that DynamoDB failed to replicate."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 1,
+        "datapointsToAlarm": 1,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TableName"
+          },
+          {
+            "name": "DelegatedOperation"
+          }
+        ],
+        "intent": "This alarm can monitor the number of records that DynamoDB failed to replicate to your Kinesis data stream because of the item size limit of Kinesis Data Streams."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "MaxProvisionedTableReadCapacityUtilization",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The percentage of provisioned read capacity utilized by the highest provisioned read table or global secondary index of an account.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "MaxProvisionedTableWriteCapacityUtilization",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The percentage of provisioned write capacity utilized by the highest provisioned write table or global secondary index of an account.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "OnlineIndexConsumedWriteCapacity",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of write capacity units consumed when adding a new global secondary index to a table. If the write capacity of the index is too low, incoming write activity during the backfill phase might be throttled. This can increase the time it takes to create the index. You should monitor this statistic while the index is being built to determine whether the write capacity of the index is underprovisioned. You can adjust the write capacity of the index using the `UpdateTable` operation, even while the index is still being built. The `ConsumedWriteCapacityUnits` metric for the index doesn't include the write throughput consumed during index creation. Note: This metric may not be emitted if the new global secondary index’s backfill phase completes quickly (less than a few minutes), which may occur if the base table has few or no items to backfill in the index.",
+    "recommendedStatistics": "Maximum, Minimum, Average, SampleCount, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "OnlineIndexPercentageProgress",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The percentage of completion when a new global secondary index is being added to a table. DynamoDB must first allocate resources for the new index, and then backfill attributes from the table into the index. For large tables, this process might take a long time. You should monitor this statistic to view the relative progress as DynamoDB builds the index.",
+    "recommendedStatistics": "Minimum, Maximum, Average, SampleCount, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "OnlineIndexThrottleEvents",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of write throttle events that occur when adding a new global secondary index to a table. These events indicate that the index creation will take longer to complete, because incoming write activity is exceeding the provisioned write throughput of the index. You can adjust the write capacity of the index using the `UpdateTable` operation, even while the index is still being built. The `WriteThrottleEvents` metric for the index doesn't include any throttle events that occur during index creation.",
+    "recommendedStatistics": "Minimum, Maximum, Average, SampleCount, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PendingReplicationCount",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "Metric for [Global tables version 2017.11.29 (Legacy)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V1.html) (global tables only). The number of item updates that are written to one replica table, but that have not yet been written to another replica in the global table.",
+    "recommendedStatistics": "Average, SampleCount, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ProvisionedReadCapacityUnits",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of provisioned read capacity units for a table or a global secondary index. The `TableName` dimension returns the `ProvisionedReadCapacityUnits` for the table, but not for any global secondary indexes. To view `ProvisionedReadCapacityUnits` for a global secondary index, you must specify both `TableName` and `GlobalSecondaryIndexName`.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ProvisionedWriteCapacityUnits",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of provisioned write capacity units for a table or a global secondary index. The `TableName` dimension returns the `ProvisionedWriteCapacityUnits` for the table, but not for any global secondary indexes. To view `ProvisionedWriteCapacityUnits` for a global secondary index, you must specify both `TableName` and `GlobalSecondaryIndexName`.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadThrottleEvents",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "Requests to DynamoDB that exceed the provisioned read capacity units for a table or a global secondary index. A single request can result in multiple events. For example, a `BatchGetItem` that reads 10 items is processed as 10 `GetItem` events. For each event, `ReadThrottleEvents` is incremented by one if that event is throttled. The `ThrottledRequests` metric for the entire `BatchGetItem` is not incremented unless all 10 of the `GetItem` events are throttled. The `TableName` dimension returns the `ReadThrottleEvents` for the table, but not for any global secondary indexes. To view `ReadThrottleEvents` for a global secondary index, you must specify both `TableName` and `GlobalSecondaryIndexName`.",
+    "recommendedStatistics": "SampleCount, Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects if there are high number of read requests getting throttled for the DynamoDB table. To troubleshoot the issue, see [Troubleshooting throttling issues in Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TroubleshootingThrottling.html).",
+        "threshold": {
+          "justification": "Set the threshold according to the expected read traffic for the DynamoDB table, accounting for an acceptable level of throttling. It is important to monitor whether you are under provisioned and not causing consistent throttling. You can also analyze historical data to find the acceptable throttling level for the application workload, and then tune the threshold to be higher than your usual throttling level. Throttled requests should be retried by the application or service as they are transient. Therefore, a very low threshold may cause the alarm to be too sensitive, causing unwanted state transitions."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TableName"
+          }
+        ],
+        "intent": "This alarm can detect sustained throttling for read requests to the DynamoDB table. Sustained throttling of read requests can negatively impact your workload read operations and reduce the overall efficiency of the system."
+      },
+      {
+        "alarmDescription": "This alarm detects if there are a high number of read requests getting throttled for the Global Secondary Index of the DynamoDB table. To troubleshoot the issue, see [Troubleshooting throttling issues in Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TroubleshootingThrottling.html).",
+        "threshold": {
+          "justification": "Set the threshold according to the expected read traffic for the DynamoDB table, accounting for an acceptable level of throttling. It is important to monitor if you are under provisioned and not causing consistent throttling. You can also analyze historical data to find an acceptable throttling level for the application workload, and then tune the threshold to be higher than your usual acceptable throttling level. Throttled requests should be retried by the application or service as they are transient. Therefore, a very low threshold may cause the alarm to be too sensitive, causing unwanted state transitions."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TableName"
+          },
+          {
+            "name": "GlobalSecondaryIndexName"
+          }
+        ],
+        "intent": "The alarm can detect sustained throttling for read requests for the Global Secondary Index of the DynamoDB Table. Sustained throttling of read requests can negatively impact your workload read operations and reduce the overall efficiency of the system."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ReplicationLatency",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "(This metric is for DynamoDB global tables.) The elapsed time between an updated item appearing in the DynamoDB stream for one replica table, and that item appearing in another replica in the global table.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Milliseconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "The alarm detects if the replica in a Region for the global table is lagging behind the source Region. The latency can increase if an AWS Region becomes degraded and you have a replica table in that Region. In this case, you can temporarily redirect your application's read and write activity to a different AWS Region. If you are using 2017.11.29 (Legacy) of global tables, you should verify that write capacity units (WCUs) are identical for each of the replica tables. You can also make sure to follow recommendations in [Global tables version Best practices and requirements for managing capacity](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables_reqs_bestpractices.html#globaltables_reqs_bestpractices.tables).",
+        "threshold": {
+          "justification": "The recommended threshold value for this alarm is highly dependent on your use case. Replication latencies longer than 3 minutes are generally a cause for investigation. Review the criticality and requirements of replication delay and analyze historical trends, and then select the threshold accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "TableName"
+          },
+          {
+            "name": "ReceivingRegion"
+          }
+        ],
+        "intent": "The alarm can detect if the replica table in a Region is falling behind replicating the changes from another Region. This could cause your replica to diverge from the other replicas. It’s useful to know the replication latency of each AWS Region and alert if that replication latency increases continually. The replication of the table applies to global tables only."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ReturnedBytes",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of bytes returned by `GetRecords` operations (Amazon DynamoDB Streams) during the specified time period.",
+    "recommendedStatistics": "Minimum, Maximum, Average, SampleCount, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ReturnedItemCount",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of items returned by `Query`, `Scan` or `ExecuteStatement` (select) operations during the specified time period. The number of items returned is not necessarily the same as the number of items that were evaluated. For example, suppose that you requested a `Scan` on a table or an index that had 100 items, but specified a `FilterExpression` that narrowed the results so that only 15 items were returned. In this case, the response from `Scan` would contain a `ScanCount` of 100 and a `Count` of 15 returned items.",
+    "recommendedStatistics": "Minimum, Maximum, Average, SampleCount, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ReturnedRecordsCount",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of stream records returned by `GetRecords` operations (Amazon DynamoDB Streams) during the specified time period.",
+    "recommendedStatistics": "Minimum, Maximum, Average, SampleCount, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SuccessfulRequestLatency",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The latency of successful requests to DynamoDB or Amazon DynamoDB Streams during the specified time period. `SuccessfulRequestLatency` can provide two different kinds of information: The elapsed time for successful requests (Minimum, Maximum, Sum, or Average). The number of successful requests (SampleCount). `SuccessfulRequestLatency` reflects activity only within DynamoDB or Amazon DynamoDB Streams, and doesn't consider network latency or client-side activity.",
+    "recommendedStatistics": "Minimum, Maximum, Average, SampleCount (Number of successful requests)",
+    "unitInfo": "Milliseconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects a high latency for the DynamoDB table operation ( indicated by the dimension value of the `Operation` in the alarm). See [this troubleshooting document](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TroubleshootingLatency.html) for troubleshooting latency issues in Amazon DynamoDB.",
+        "threshold": {
+          "justification": "DynamoDB provides single-digit millisecond latency on average for singleton operations such as GetItem, PutItem, and so on. However, you can set the threshold based on acceptable tolerance for the latency for the type of operation and table involved in the workload. You can analyze historical data of this metric to find the usual latency for the table operation, and then set the threshold to a number which represents critical delay for the operation."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "TableName"
+          },
+          {
+            "name": "Operation"
+          }
+        ],
+        "intent": "This alarm can detect a high latency for the DynamoDB table operation. Higher latency for the operations can negatively impact the overall efficiency of the system."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "SystemErrors",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The requests to DynamoDB or Amazon DynamoDB Streams that generate an HTTP 500 status code during the specified time period. An HTTP 500 usually indicates an internal service error.",
+    "recommendedStatistics": "Sum, SampleCount",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects a sustained high number of system errors for the DynamoDB table requests. If you continue to get 5xx errors, open the [AWS Service Health Dashboard](https://status.aws.amazon.com/) to check for operational issues with the service. You can use this alarm to get notified in case there is a prolonged internal service issue from DynamoDB and it helps you correlate with the issue your client application is facing. Refer [Error handling for DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html#Programming.Errors.MessagesAndCodes.http5xx) for more information.",
+        "threshold": {
+          "justification": "Set the threshold according to the expected traffic, accounting for an acceptable level of system errors. You can also analyze historical data to find the acceptable error count for the application workload, and then tune the threshold accordingly. System errors should be retried by the application/service as they are transient. Therefore, a very low threshold might cause the alarm to be too sensitive, causing unwanted state transitions."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TableName"
+          }
+        ],
+        "intent": "This alarm can detect sustained system errors for the DynamoDB table requests. System errors indicate internal service errors from DynamoDB and helps correlate to the issue that the client is having."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "TimeToLiveDeletedItemCount",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of items deleted by Time to Live (TTL) during the specified time period. This metric helps you monitor the rate of TTL deletions on your table.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ThrottledPutRecordCount",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of records that were throttled by your Kinesis data stream due to insufficient Kinesis Data Streams capacity.",
+    "recommendedStatistics": "Minimum, Maximum, Average, SampleCount",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects the records getting throttled by your Kinesis data stream during the replication of change data capture to Kinesis. This throttling happens because of insufficient Kinesis data stream capacity. If you experience excessive and regular throttling, you might need to increase the number of Kinesis stream shards proportionally to the observed write throughput of your table. To learn more about determining the size of a Kinesis data stream, see [Determining the Initial Size of a Kinesis Data Stream](https://docs.aws.amazon.com/streams/latest/dev/amazon-kinesis-streams.html#how-do-i-size-a-stream).",
+        "threshold": {
+          "justification": "You might experience some throttling during exceptional usage peaks, but throttled records should remain as low as possible to avoid higher replication latency (DynamoDB retries sending throttled records to the Kinesis data stream). Set the threshold to a number which can help you catch regular excessive throttling. You can also analyze historical data of this metric to find the acceptable throttling rates for the application workload. Tune the threshold to a value that the application can tolerate based on your use case."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TableName"
+          },
+          {
+            "name": "DelegatedOperation"
+          }
+        ],
+        "intent": "This alarm can monitor the number of records that that were throttled by your Kinesis data stream because of insufficient Kinesis data stream capacity."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ThrottledRequests",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "Requests to DynamoDB that exceed the provisioned throughput limits on a resource (such as a table or an index). `ThrottledRequests` is incremented by one if any event within a request exceeds a provisioned throughput limit. For example, if you update an item in a table with global secondary indexes, there are multiple events—a write to the table, and a write to each index. If one or more of these events are throttled, then `ThrottledRequests` is incremented by one. To gain insight into which event is throttling a request, compare `ThrottledRequests` with the `ReadThrottleEvents` and `WriteThrottleEvents` for the table and its indexes. Note: In a batch request (`BatchGetItem` or `BatchWriteItem`), `ThrottledRequests` is incremented only if every request in the batch is throttled. If any individual request within the batch is throttled, one of the following metrics is incremented: `ReadThrottleEvents` – For a throttled `GetItem` event within `BatchGetItem`. `WriteThrottleEvents` – For a throttled `PutItem` or `DeleteItem` event within `BatchWriteItem`. Note: A throttled request will result in an HTTP 400 status code. All such events are reflected in the `ThrottledRequests` metric, but not in the `UserErrors` metric.",
+    "recommendedStatistics": "Sum, SampleCount",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "TransactionConflict",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "Rejected item-level requests due to transactional conflicts between concurrent requests on the same items. For more information, see [Transaction Conflict Handling in DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html#transaction-conflict-handling). Note: If multiple item-level requests within a call to `TransactWriteItems` or `TransactGetItems` were rejected, Sum is incremented by one for each item-level `Put`, `Update`, `Delete`, or `Get` request. Note: If multiple item-level requests within a call to `TransactWriteItems` or `TransactGetItems` are rejected, SampleCount is only incremented by one.",
+    "recommendedStatistics": "Sum, SampleCount, Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "UserErrors",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "Requests to DynamoDB or Amazon DynamoDB Streams that generate an HTTP 400 status code during the specified time period. An HTTP 400 usually indicates a client-side error, such as an invalid combination of parameters, an attempt to update a nonexistent table, or an incorrect request signature. Some examples of exceptions that will log metrics related to `UserErrors` would be: `ResourceNotFoundException`. `ValidationException`. `TransactionConflict`. All such events are reflected in the `UserErrors` metric, except for the following: ProvisionedThroughputExceededException – See the `ThrottledRequests` metric in this section. ConditionalCheckFailedException – See the `ConditionalCheckFailedRequests` metric in this section. `UserErrors` represents the aggregate of HTTP 400 errors for DynamoDB or Amazon DynamoDB Streams requests for the current AWS Region and the current AWS account.",
+    "recommendedStatistics": "Sum, SampleCount",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects a sustained high number of user errors for the DynamoDB table requests. You can check client application logs during the issue time frame to see why the requests are invalid. You can check [HTTP status code 400](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html#Programming.Errors.MessagesAndCodes.http400) to see the type of error you are getting and take action accordingly. You might have to fix the application logic to create valid requests.",
+        "threshold": {
+          "justification": "Set the threshold to zero to detect any client side errors. Or you can set it to a higher value if you want to avoid the alarm triggering for a very lower number of errors. Decide based on your use case and traffic for the requests."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "missing",
+        "dimensions": [],
+        "intent": "This alarm can detect sustained user errors for the DynamoDB table requests. User errors for requested operations mean that the client is producing invalid requests and it is failing."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "WriteThrottleEvents",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "Requests to DynamoDB that exceed the provisioned write capacity units for a table or a global secondary index. A single request can result in multiple events. For example, a `PutItem` request on a table with three global secondary indexes would result in four events—the table write, and each of the three index writes. For each event, the `WriteThrottleEvents` metric is incremented by one if that event is throttled. For single `PutItem` requests, if any of the events are throttled, `ThrottledRequests` is also incremented by one. For `BatchWriteItem`, the `ThrottledRequests` metric for the entire `BatchWriteItem` is not incremented unless all of the individual `PutItem` or `DeleteItem` events are throttled. The `TableName` dimension returns the `WriteThrottleEvents` for the table, but not for any global secondary indexes. To view `WriteThrottleEvents` for a global secondary index, you must specify both `TableName` and `GlobalSecondaryIndexName`.",
+    "recommendedStatistics": "Sum, SampleCount",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects if there are a high number of write requests getting throttled for the DynamoDB table. See [Troubleshooting throttling issues in Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TroubleshootingThrottling.html) to troubleshoot the issue.",
+        "threshold": {
+          "justification": "Set the threshold according to the expected write traffic for the DynamoDB table, accounting for an acceptable level of throttling. It is important to monitor if you are under provisioned and not causing consistent throttling. You can also analyze historical data to find the acceptable level of throttling for the application workload, and then tune the threshold to a value higher than your usual acceptable throttling level. Throttled requests should be retried by the application/service as they are transient. Therefore, a very low threshold might cause the alarm to be too sensitive, causing unwanted state transitions."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TableName"
+          }
+        ],
+        "intent": "This alarm can detect sustained throttling for write requests to the DynamoDB table. Sustained throttling of write requests can negatively impact your workload write operations and reduce the overall efficiency of the system."
+      },
+      {
+        "alarmDescription": "This alarm detects if there are a high number of write requests getting throttled for Global Secondary Index of the DynamoDB table. See [Troubleshooting throttling issues in Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TroubleshootingThrottling.html) to troubleshoot the issue.",
+        "threshold": {
+          "justification": "Set the threshold according to the expected Write traffic for the DynamoDB table, accounting for an acceptable level of throttling. It is important to monitor if you are under provisioned and not causing consistent throttling. You can also analyze historical data to find the acceptable throttling level for the application workload, and then tune the threshold to a value higher than your usual acceptable throttling level. Throttled requests should be retried by the application/service as they are transient. Therefore, a very low value might cause the alarm to be too sensitive, causing unwanted state transitions."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TableName"
+          },
+          {
+            "name": "GlobalSecondaryIndexName"
+          }
+        ],
+        "intent": "This alarm can detect sustained throttling for write requests for the Global Secondary Index of DynamoDB Table. Sustained throttling of write requests can negatively impact your workload write operations and reduce the overall efficiency of the system."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "OnDemandMaxReadRequestUnits",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of specified on-demand read request units for a table or a global secondary index. To view `OnDemandMaxReadRequestUnits` for a table, you must specify `TableName`. To view `OnDemandMaxReadRequestUnits` for a global secondary index, you must specify both `TableName` and `GlobalSecondaryIndexName`.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "OnDemandMaxWriteRequestUnits",
+      "namespace": "AWS/DynamoDB"
+    },
+    "description": "The number of specified on-demand write request units for a table or a global secondary index. To view `OnDemandMaxWriteRequestUnits` for a table, you must specify `TableName`. To view `OnDemandMaxWriteRequestUnits` for a global secondary index, you must specify both `TableName` and `GlobalSecondaryIndexName`.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SignUpSuccesses",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Provides the total number of successful user registration requests made to the Amazon Cognito user pool. A successful user registration request produces a value of 1, whereas an unsuccessful request produces a value of 0. A throttled request is also considered as an unsuccessful request, and hence a throttled request will also produce a count of 0. To find the percentage of successful user registration requests, use the Average statistic on this metric. To count the total number of user registration requests, use the Sample Count statistic on this metric. To count the total number of successful user registration requests, use the Sum statistic on this metric. To count the total number of failed user registration requests, use the CloudWatch `Math` expression and subtract the Sum statistic from the Sample Count statistic. This metric is published for each user pool for each user pool client. In case when the user registration is performed by an admin, the metric is published with the user pool client as `Admin`. Note that this metric is not emitted for [User import](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-using-import-tool.html) and [User migration](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-import-using-lambda.html) cases.",
+    "recommendedStatistics": "Average, Sample Count, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SignUpThrottles",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Provides the total number of throttled user registration requests made to the Amazon Cognito user pool. A count of 1 is published whenever a user registration request is throttled. To count the total number of throttled user registration requests, use the Sum statistic for this metric. This metric is published for each user pool for each client. In case when the request that was throttled was made by an administrator, the metric is published with user pool client as `Admin`.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm monitors the count of throttled requests. If users are consistently getting throttled, you should increase the limit by requesting a service quota increase. Refer to [Quotas in Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html) to learn how to request a quota increase. To take actions proactively, consider tracking the [usage quota](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html#track-quota-usage).",
+        "threshold": {
+          "justification": "A well-provisioned user pool should not encounter any throttling which spans across multiple data points. So, a typical threshold for an expected workload should be zero. For an irregular workload with frequent bursts, you can analyze historical data to determine the acceptable throttling for the application workload, and then you can tune the threshold accordingly. A throttled request should be retried to minimize the impact on the application."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "UserPool"
+          },
+          {
+            "name": "UserPoolClient"
+          }
+        ],
+        "intent": "This alarm helps to monitor the occurrence of throttled sign-up requests. This can help you know when to take actions to mitigate any degradation in sign-up experience. Sustained throttling of requests is a negative user sign-up experience."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "SignInSuccesses",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Provides the total number of successful user authentication requests made to the Amazon Cognito user pool. A user authentication is considered successful when authentication token is issued to the user. A successful authentication produces a value of 1, whereas an unsuccessful request produces a value of 0. A throttled request is also considered as an unsuccessful request, and hence a throttled request will also produce a count of 0. To find the percentage of successful user authentication requests, use the Average statistic on this metric. To count the total number of user authentication requests, use the Sample Count statistic on this metric. To count the total number of successful user authentication requests, use the Sum statistic on this metric. To count the total number of failed user authentication requests, use the CloudWatch `Math` expression and subtract the Sum statistic from the Sample Count statistic. This metric is published for each user pool for each client. In case an invalid user pool client is provided with a request, the corresponding user pool client value in the metric contains a fixed value `Invalid` instead of the actual invalid value sent in the request. Note that requests to refresh the Amazon Cognito token is not included in this metric. There is a separate metric for providing `Refresh` token statistics.",
+    "recommendedStatistics": "Average, Sample Count, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SignInThrottles",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Provides the total number of throttled user authentication requests made to the Amazon Cognito user pool. A count of 1 is published whenever an authentication request is throttled. To count the total number of throttled user authentication requests, use the Sum statistic for this metric. This metric is published for each user pool for each client. In case an invalid user pool client is provided with a request, the corresponding user pool client value in the metric contains a fixed value `Invalid` instead of the actual invalid value sent in the request. Requests to refresh Amazon Cognito token is not included in this metric. There is a separate metric for providing `Refresh` token statistics.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm monitors the count of throttled user authentication requests. If users are consistently getting throttled, you might need to increase the limit by requesting a service quota increase. Refer to [Quotas in Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html) to learn how to request a quota increase. To take actions proactively, consider tracking the [usage quota](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html#track-quota-usage).",
+        "threshold": {
+          "justification": "A well-provisioned user pool should not encounter any throttling which spans across multiple data points. So, a typical threshold for an expected workload should be zero. For an irregular workload with frequent bursts, you can analyze historical data to determine the acceptable throttling for the application workload, and then you can tune the threshold accordingly. A throttled request should be retried to minimize the impact on the application."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "UserPool"
+          },
+          {
+            "name": "UserPoolClient"
+          }
+        ],
+        "intent": "This alarm helps to monitor the occurrence of throttled sign-in requests. This can help you know when to take actions to mitigate any degradation in sign-in experience. Sustained throttling of requests is a bad user authentication experience."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "TokenRefreshSuccesses",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Provides the total number of successful requests to refresh an Amazon Cognito token that were made to the Amazon Cognito user pool. A successful refresh Amazon Cognito token request produces a value of 1, whereas an unsuccessful request produces a value of 0. A throttled request is also considered as an unsuccessful request, and hence a throttled request will also produce a count of 0. To find the percentage of successful requests to refresh an Amazon Cognito token, use the Average statistic on this metric. To count the total number of requests to refresh an Amazon Cognito token, use the Sample Count statistic on this metric. To count the total number of successful requests to refresh an Amazon Cognito token, use the Sum statistic on this metric. To count the total number of failed requests to refresh an Amazon Cognito token, use the CloudWatch `Math` expression and subtract the Sum statistic from the Sample Count statistic. This metric is published per each user pool client. If an invalid user pool client is in a request, the user pool client value contains a fixed value of `Invalid`.",
+    "recommendedStatistics": "Average, Sample Count, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "TokenRefreshThrottles",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Provides the total number of throttled requests to refresh an Amazon Cognito token that were made to the Amazon Cognito user pool. A count of 1 is published whenever a refresh Amazon Cognito token request is throttled. To count the total number of throttled requests to refresh an Amazon Cognito token, use the Sum statistic for this metric. This metric is published for each user pool for each client. In case an invalid user pool client is provided with a request, corresponding user pool client value in the metric contains a fixed value `Invalid` instead of the actual invalid value sent in the request.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "You can set the threshold value can to suit the traffic of the request as well as to match acceptable throttling for token refresh requests. Throttling is used to protect your system from too many requests. However, it is important to monitor if you are under provisioned for your normal traffic as well. You can analyze historical data to find the acceptable throttling for the application workload, and then you can tune your alarm threshold to be higher than your acceptable throttling level. Throttled requests should be retried by the application/service as they are transient. Therefore, a very low value for the threshold can cause alarm to be sensitive.",
+        "threshold": {
+          "justification": "Threshold value can also be set/tuned to suit the traffic of the request as well as acceptable throttling for token refresh requests. Throttling are there for protecting your system from too many requests, however it is important to monitor if you are under provisioned for your normal traffic as well and see if it is causing the impact. Historical data can also be analyzed to see what is the acceptable throttling for the application workload and threshold can be tuned higher than your usual acceptable throttling level. Throttled requests should be retried by the application/service as they are transient. Therefore, a very low value for the threshold can cause alarm to be sensitive."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "UserPool"
+          },
+          {
+            "name": "UserPoolClient"
+          }
+        ],
+        "intent": "This alarm helps to monitor the occurrence of throttled token refresh requests. This can help you know when to take actions to mitigate any potential problems, to ensure a smooth user experience and the health and reliability of your authentication system. Sustained throttling of requests is a bad user authentication experience."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "FederationSuccesses",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Provides the total number of successful identity federation requests to the Amazon Cognito user pool. An identity federation is considered successful when Amazon Cognito issues authentication tokens to the user. A successful identity federation request produces a value of 1, whereas an unsuccessful request produces a value of 0. Throttled requests and requests that generate an authorization code but no tokens produce a value of 0. To find the percentage of successful identity federation requests, use the Average statistic on this metric. To count the total number of identity federation requests, use the Sample Count statistic on this metric. To count the total number of successful identity federation requests, use the Sum statistic on this metric. To count the total number of failed identity federation requests, use the CloudWatch `Math` expression and subtract the Sum statistic from the Sample Count statistic.",
+    "recommendedStatistics": "Average, Sample Count, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "FederationThrottles",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Provides the total number of throttled identity federation requests to the Amazon Cognito user pool. A count of 1 is published whenever an identity federation request is throttled. To count the total number of throttled identity federation requests, use the Sum statistic for this metric.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm monitors the count of throttled identity federation requests. If you consistently see throttling, it might indicate that you need to increase the limit by requesting a service quota increase. Refer to [Quotas in Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html) to learn how to request a quota increase.",
+        "threshold": {
+          "justification": "You can set the threshold to suit the traffic of the request as well as to match the acceptable throttling for identity federation requests. Throttling is used for protecting your system from too many requests. However, it is important to monitor if you are under provisioned for your normal traffic as well. You can analyze historical data to find the acceptable throttling for the application workload, and then set the threshold to a value above your acceptable throttling level. Throttled requests should be retried by the application/service as they are transient. Therefore, a very low value for the threshold can cause alarm to be sensitive."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "UserPool"
+          },
+          {
+            "name": "UserPoolClient"
+          },
+          {
+            "name": "IdentityProvider"
+          }
+        ],
+        "intent": "This alarm helps to monitor the occurrence of throttled identity federation requests. This can help you take proactive responses to performance bottlenecks or misconfigurations, and ensure a smooth authentication experience for your users. Sustained throttling of requests is a bad user authentication experience."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "CompromisedCredentialRisk",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Requests where Amazon Cognito detected compromised credentials.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AccountTakeoverRisk",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Requests where Amazon Cognito detected account take-over risk.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "OverrideBlock",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Requests that Amazon Cognito blocked because of the configuration provided by the developer.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "Risk",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Requests that Amazon Cognito marked as risky.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NoRisk",
+      "namespace": "AWS/Cognito"
+    },
+    "description": "Requests where Amazon Cognito did not identify any risk.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerInstanceCount",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of EC2 instances running the Amazon ECS agent that are registered with a cluster. This metric is collected only for container instances that are running Amazon ECS tasks in the cluster. It is not collected for empty container instances that do not have any Amazon ECS tasks.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CpuUtilized",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The CPU units used by tasks in the resource that is specified by the dimension set that you're using. This metric is collected only for tasks that have a defined CPU reservation in their task definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerCpuUtilized",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The CPU units used by container in the resource that is specified by the dimension set that you're using. This metric is collected only for container that have a defined CPU reservation in their container definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "CpuReserved",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The CPU units reserved by tasks in the resource that is specified by the dimension set that you're using. This metric is collected only for tasks that have a defined CPU reservation in their task definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerCpuReserved",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The CPU units reserved by container in the resource that is specified by the dimension set that you're  using. This metric is collected only for container that have a defined CPU reservation in their container definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "TaskCpuUtilization",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The percentage of CPU units used by the tasks. Formula: CpuUtilized / CpuReserved. This metric is collected only for tasks that have a defined CPU reservation in their task definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect high CPU utilization of tasks in your ECS cluster. If task CPU utilization is consistently high, you might need to optimize your tasks or increase their CPU reservation.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to about 80% of the task's CPU reservation. You can adjust this value based on your acceptable CPU utilization for the tasks. For some workloads, consistently high CPU utilization might be normal, while for others, it might indicate performance issues or the need for more resources."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm is used to detect high CPU utilization for tasks in the ECS cluster. Consistent high CPU utilization can indicate that the tasks are under stress and might need more CPU resources or optimization to maintain performance."
+      },
+      {
+        "alarmDescription": "This alarm helps you detect high CPU utilization of tasks belonging to the ECS service. If task CPU utilization is consistently high, you might need to optimize your tasks or increase their CPU reservation.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to about 80% of the task's CPU reservation. You can adjust this value based on your acceptable CPU utilization for the tasks. For some workloads, consistently high CPU utilization might be normal, while for others, it might indicate performance issues or the need for more resources."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "ServiceName"
+          }
+        ],
+        "intent": "This alarm is used to detect high CPU utilization for tasks belonging to the ECS service. Consistent high CPU utilization can indicate that the tasks are under stress and might need more CPU resources or optimization to maintain performance."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerCpuUtilization",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The percentage of CPU units used by the container. Formula: ContainerCpuUtilized / ContainerCpuReserved. This metric is collected only for containers that have a defined CPU reservation in their container definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm monitors the percentage of CPU units used by containers in your ECS cluster relative to their reserved CPU. It helps detect when containers are approaching their CPU limits based on the ContainerCpuUtilized/ContainerCpuReserved ratio.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to about 80% of the container's CPU utilization ratio. This provides an early warning when containers are approaching their CPU capacity limits while allowing for normal fluctuations in CPU usage. The threshold can be adjusted based on your workload characteristics and performance requirements."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm detects when containers in the ECS cluster are using a high percentage of their reserved CPU capacity, calculated as ContainerCpuUtilized/ContainerCpuReserved. Sustained high values indicate containers are operating near their CPU limits and might need capacity adjustments."
+      },
+      {
+        "alarmDescription": "This alarm monitors the percentage of CPU units used by containers belonging to the ECS service relative to their reserved CPU. It helps detect when containers are approaching their CPU limits based on the ContainerCpuUtilized/ContainerCpuReserved ratio.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to about 80% of the container's CPU utilization ratio. This provides an early warning when containers are approaching their CPU capacity limits while allowing for normal fluctuations in CPU usage. The threshold can be adjusted based on your workload characteristics and performance requirements."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "ServiceName"
+          }
+        ],
+        "intent": "This alarm detects when containers belonging to the ECS service are using a high percentage of their reserved CPU capacity, calculated as ContainerCpuUtilized/ContainerCpuReserved. Sustained high values indicate containers are operating near their CPU limits and might need capacity adjustments."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "DeploymentCount",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of deployments in an Amazon ECS service.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum, SampleCount",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DesiredTaskCount",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The desired number of tasks for an Amazon ECS service.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "EphemeralStorageReserved",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of bytes reserved from ephemeral storage in the resource that is specified by the dimensions that you're using. Ephemeral storage is used for the container root filesystem and any bind mount host volumes defined in the container image and task definition. The amount of ephemeral storage can’t be changed in a running task. This metric is only available for tasks that run on Fargate Linux platform version 1.4.0 or later.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Gigabytes (GB)"
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerEphemeralStorageReserved",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of bytes reserved from ephemeral storage in the resource that is specified by the dimensions that you're using. Ephemeral storage is used for the container root filesystem and any bind mount host volumes defined in the container image and task definition. The amount of ephemeral storage can't be changed in a running task. This metric is only available for tasks that run on Fargate Linux platform  version 1.4.0 or later.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Gigabytes (GB)"
+  },
+  {
+    "metricId": {
+      "metricName": "EphemeralStorageUtilized",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of bytes used from ephemeral storage in the resource that is specified by the dimensions that you're using. Ephemeral storage is used for the container root filesystem and any bind mount host volumes defined in the container image and task definition. The amount of ephemeral storage can’t be changed in a running task. This metric is only available for tasks that run on Fargate Linux platform version 1.4.0 or later.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Gigabytes (GB)",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect high ephemeral storage utilized of the Fargate cluster. If ephemeral storage is consistently high, you can check ephemeral storage usage and increase the ephemeral storage.",
+        "threshold": {
+          "staticValue": 90.0,
+          "justification": "Set the threshold to about 90% of the ephemeral storage size. You can adjust this value based on your acceptable ephemeral storage utilization of the Fargate cluster. For some systems, a consistently high ephemeral storage utilized might be normal, while for others, it might lead to failure of the container."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "ServiceName"
+          }
+        ],
+        "intent": "This alarm is used to detect high ephemeral storage usage for the Fargate cluster. Consistent high ephemeral storage utilized can indicate that the disk is full and it might lead to failure of the container."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerEphemeralStorageUtilized",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of bytes used from  ephemeral storage in the resource that is specified by the dimensions that you're using. Ephemeral storage is used for the container root filesystem and  any bind mount host volumes defined in the container image and task definition.  The amount of ephemeral storage can't be changed in a running task. This metric is only available for tasks that run on Fargate Linux platform  version 1.4.0 or later.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Gigabytes (GB)"
+  },
+  {
+    "metricId": {
+      "metricName": "TaskEphemeralStorageUtilization",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The percentage of storage bytes used by the task. Formula: EphemeralStorageUtilized / EphemeralStorageReserved. This metric is only available for tasks that run on Fargate Linux platform  version 1.4.0 or later. This metric is only available for tasks that run on Fargate Linux platform  version 1.4.0 or later.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect high ephemeral storage utilization of tasks in your ECS cluster. If storage utilization is consistently high, you might need to optimize your storage usage or increase the storage reservation.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to about 80% of the task's ephemeral storage reservation. You can adjust this value based on your acceptable storage utilization for the tasks. For some workloads, consistently high storage utilization might be normal, while for others, it might indicate potential disk space issues or the need for more storage."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm is used to detect high ephemeral storage utilization for tasks in the ECS cluster. Consistent high storage utilization can indicate that the task is running out of disk space and might need more storage resources or optimization to maintain proper operation."
+      },
+      {
+        "alarmDescription": "This alarm helps you detect high ephemeral storage utilization of tasks belonging to the ECS service. If storage utilization is consistently high, you might need to optimize your storage usage or increase the storage reservation.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to about 80% of the task's ephemeral storage reservation. You can adjust this value based on your acceptable storage utilization for the tasks. For some workloads, consistently high storage utilization might be normal, while for others, it might indicate potential disk space issues or the need for more storage."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "ServiceName"
+          }
+        ],
+        "intent": "This alarm is used to detect high ephemeral storage utilization for tasks belonging to the ECS service. Consistent high storage utilization can indicate that the task is running out of disk space and might need more storage resources or optimization to maintain proper operation."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerEphemeralStorageUtilzation",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The percentage of storage bytes used by the container. Formula: ContainerEphemeralStorageUtilized /  ContainerEphemeralStorageReserved. This metric is only available for tasks that run on Fargate Linux platform  version 1.4.0 or later.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "MemoryUtilized",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The memory being used by tasks in the resource that is specified by the dimension set that you're using. This metric is collected only for tasks that have a defined memory reservation in their task definition. Note: If you're using the Java ZGC garbage collector for your application, this metric might be inaccurate.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Megabytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerMemoryUtilized",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The memory being used by containers in the resource that is specified by the dimension set  that you're using. This metric is collected only for containers that have a defined memory reservation in their container definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Megabytes"
+  },
+  {
+    "metricId": {
+      "metricName": "MemoryReserved",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The memory that is reserved by tasks in the resource that is specified by the dimension set that you're using. This metric is collected only for tasks that have a defined memory reservation in their task definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Megabytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerMemoryReserved",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The memory that is reserved by containers in the resource that is specified by the dimension set  that you're using. This metric is collected only for containers that have a defined memory reservation in their container definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Megabytes"
+  },
+  {
+    "metricId": {
+      "metricName": "TaskMemoryUtilization",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The percentage of memory used by the task. Formula: MemoryUtilized / MemoryReserved. This metric is collected only for tasks that have a defined memory  reservation in their task definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect high memory utilization of tasks in your ECS cluster. If memory utilization is consistently high, you might need to optimize your tasks or increase the memory reservation.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to about 80% of the task's memory reservation. You can adjust this value based on your acceptable memory utilization for the tasks. For some workloads, consistently high memory utilization might be normal, while for others, it might indicate memory pressure or the need for more resources."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm is used to detect high memory utilization for tasks in the ECS cluster. Consistent high memory utilization can indicate that the task is under memory pressure and might need more memory resources or optimization to maintain stability."
+      },
+      {
+        "alarmDescription": "This alarm helps you detect high memory utilization of tasks belonging to the ECS service. If memory utilization is consistently high, you might need to optimize your tasks or increase the memory reservation.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to about 80% of the task's memory reservation. You can adjust this value based on your acceptable memory utilization for the tasks. For some workloads, consistently high memory utilization might be normal, while for others, it might indicate memory pressure or the need for more resources."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "ServiceName"
+          }
+        ],
+        "intent": "This alarm is used to detect high memory utilization for tasks belonging to the ECS service. Consistent high memory utilization can indicate that the task is under memory pressure and might need more memory resources or optimization to maintain stability."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerMemoryUtilization",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The percentage of memory used by the container. Formula: ContainerMemoryUtilized / ContainerMemoryReserved. TThis metric is collected only for containers that have a defined memory reservation in their container definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect high memory utilization of containers in your ECS cluster. If memory utilization is consistently high, you might need to optimize your containers or increase the memory reservation.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to about 80% of the container's memory reservation. You can adjust this value based on your acceptable memory utilization for the containers. For some workloads, consistently high memory utilization might be normal, while for others, it might indicate memory pressure or the need for more resources."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm is used to detect high memory utilization for containers in the ECS cluster. Consistent high memory utilization can indicate that the container is under memory pressure and might need more memory resources or optimization to maintain stability."
+      },
+      {
+        "alarmDescription": "This alarm helps you detect high memory utilization of containers belonging to the ECS service. If memory utilization is consistently high, you might need to optimize your containers or increase the memory reservation.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to about 80% of the container's memory reservation. You can adjust this value based on your acceptable memory utilization for the containers. For some workloads, consistently high memory utilization might be normal, while for others, it might indicate memory pressure or the need for more resources."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "ServiceName"
+          }
+        ],
+        "intent": "This alarm is used to detect high memory utilization for containers belonging to the ECS service. Consistent high memory utilization can indicate that the container is under memory pressure and might need more memory resources or optimization to maintain stability."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkRxBytes",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of bytes received by the resource that is specified by the dimensions that you're using. This metric is obtained from the Docker runtime. This metric is available only for containers in tasks using the `awsvpc` or `bridge` network modes.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerNetworkRxBytes",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of bytes received by the resource that is specified by the dimensions that you're using. This metric is obtained from the Docker runtime. This metric is available only for containers in tasks using the awsvpc or bridge network modes.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkTxBytes",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of bytes transmitted by the resource that is specified by the dimensions that you're using. This metric is obtained from the Docker runtime. This metric is available only for containers in tasks using the `awsvpc` or `bridge` network modes.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerNetworkTxBytes",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of bytes transmitted by the resource that is specified by the dimensions that you're using. This metric is obtained from the Docker runtime. This metric is available only for containers in tasks using the awsvpc or bridge network modes.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "PendingTaskCount",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of tasks currently in the `PENDING` state.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "RunningTaskCount",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of tasks currently in the `RUNNING` state.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect a low running task count of the ECS service. If the running task count is too low, it can can indicate that the application can't handle the service load and it might lead to performance issues. If there is no running task, the ECS service might be unavailable or there might be deployment issues.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "You can adjust the threshold based on the minimum running task count of the ECS service. If the running task count is 0, the ECS service will be unavailable."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanOrEqualToThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "ServiceName"
+          }
+        ],
+        "intent": "This alarm is used to detect whether the number of running tasks are too low. A consistent low running task count can indicate ECS service deployment or performance issues."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ServiceCount",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of services in the cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "StorageReadBytes",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of bytes read from storage on the instance in the resource that is specified by the dimensions that you're using. This does not include read bytes for your storage devices. This metric is obtained from the Docker runtime.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerStorageReadBytes",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of bytes read from storage on the instance in the resource that is specified by the  dimensions that you're using. This does not include read bytes for your storage devices. This metric is obtained from the Docker runtime.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "StorageWriteBytes",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of bytes written to storage in the resource that is specified by the dimensions that you're using. This metric is obtained from the Docker runtime.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ContainerStorageWriteBytes",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of bytes written to storage in the resource that is specified by the dimensions that you're using. This metric is obtained from the Docker runtime.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "TaskCount",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of tasks running in the cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "TaskSetCount",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of task sets in the service.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "instance_cpu_limit",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The maximum number of CPU units that can be assigned to a single EC2 Instance in the cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "instance_cpu_reserved_capacity",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The percentage of CPU currently being reserved on a single EC2 instance in the cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "instance_cpu_usage_total",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of CPU units being used on a Single EC2 instance in the cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "instance_cpu_utilization",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The total percentage of CPU units being used on a single EC2 instance in the cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "instance_filesystem_utilization",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The total percentage of file system capacity being used on a single EC2 instance in the cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect a high file system utilization of the ECS cluster. If the file system utilization is consistently high, check the disk usage.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "You can set the threshold for file system utilization to about 90-95%. You can adjust this value based on the acceptable file system capacity level of the ECS cluster. For some systems, a consistently high file system utilization might be normal and not indicate a problem, while for others, it might be a cause of concern and might lead to performance issues and prevent running new tasks."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "InstanceId"
+          },
+          {
+            "name": "ContainerInstanceId"
+          },
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm is used to detect high file system utilization for the ECS cluster. A consistent high file system utilization can indicate a resource bottleneck or application performance problems, and it might prevent running new tasks."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "instance_memory_limit",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The maximum amount of memory, in bytes, that can be assigned to a single EC2 Instance in this cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "instance_memory_reserved_capacity",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The percentage of Memory currently being reserved on a single EC2 Instance in the cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "instance_memory_utilization",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The total percentage of memory being used on a single EC2 Instance in the cluster. Note: If you're using the Java ZGC garbage collector for your application, this metric might be inaccurate.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "instance_memory_working_set",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The amount of memory, in bytes, being used on a single EC2 Instance in the cluster. Note: If you're using the Java ZGC garbage collector for your application, this metric might be inaccurate.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "instance_network_total_bytes",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The total number of bytes per second transmitted and received over the network on a single EC2 Instance in the cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Bytes/second"
+  },
+  {
+    "metricId": {
+      "metricName": "instance_number_of_running_tasks",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of running tasks on a single EC2 Instance in the cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "EBSFilesystemSize",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The total amount, in gigabytes (GB), of Amazon EBS filesystem storage that is allocated to the resources specified by the dimensions you're using. This metric is only available for tasks that run on Amazon ECS infrastructure running on Fargate using platform version `1.4.0` or Amazon EC2 instances using container agent version `1.79.0` or later.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Gigabytes (GB)"
+  },
+  {
+    "metricId": {
+      "metricName": "EBSFilesystemUtilized",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The total amount, in gigabytes (GB), of Amazon EBS filesystem storage that is being used by the resources specified by the dimensions that you're using. This metric is only available for tasks that run on Amazon ECS infrastructure running on Fargate using platform version `1.4.0` or Amazon EC2 instances using container agent version `1.79.0` or later. For tasks run on Fargate, Fargate reserves space on the disk that is only used by Fargate. There is no cost associated with the space Fargate uses, but you will see this additional storage using tools like `df`.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Gigabytes (GB)"
+  },
+  {
+    "metricId": {
+      "metricName": "RestartCount",
+      "namespace": "ECS/ContainerInsights"
+    },
+    "description": "The number of times a container in an Amazon ECS task has been restarted. This metric is collected only for containers that have a restart policy enabled.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AlertManagerAlertsReceived",
+      "namespace": "AWS/Prometheus"
+    },
+    "description": "Total successful alerts received by alert manager.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "count"
+  },
+  {
+    "metricId": {
+      "metricName": "AlertManagerNotificationsFailed",
+      "namespace": "AWS/Prometheus"
+    },
+    "description": "Number of failed alert deliveries.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "count"
+  },
+  {
+    "metricId": {
+      "metricName": "AlertManagerNotificationsThrottled",
+      "namespace": "AWS/Prometheus"
+    },
+    "description": "Number of throttled alerts.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "count"
+  },
+  {
+    "metricId": {
+      "metricName": "DiscardedSamples",
+      "namespace": "AWS/Prometheus"
+    },
+    "description": "Number of discarded samples by reason.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "count"
+  },
+  {
+    "metricId": {
+      "metricName": "RuleEvaluations",
+      "namespace": "AWS/Prometheus"
+    },
+    "description": "Total number of rule evaluations.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "count"
+  },
+  {
+    "metricId": {
+      "metricName": "RuleEvaluationFailures",
+      "namespace": "AWS/Prometheus"
+    },
+    "description": "Number of rule evaluation failures in the interval.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "count"
+  },
+  {
+    "metricId": {
+      "metricName": "RuleGroupIterationsMissed",
+      "namespace": "AWS/Prometheus"
+    },
+    "description": "Number of Rule Group iterations missed in the interval.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "count"
+  },
+  {
+    "metricId": {
+      "metricName": "QuerySamplesProcessed",
+      "namespace": "AWS/Prometheus"
+    },
+    "description": "Rate of query samples processed.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "AvailableInstancePoolsCount",
+      "namespace": "AWS/EC2Spot"
+    },
+    "description": "The Spot capacity pools specified in the fleet request.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BidsSubmittedForCapacity",
+      "namespace": "AWS/EC2Spot"
+    },
+    "description": "The capacity for which Amazon EC2 has submitted fleet requests.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "EligibleInstancePoolCount",
+      "namespace": "AWS/EC2Spot"
+    },
+    "description": "The Spot capacity pools specified in the fleet request where Amazon EC2 can fulfill requests. Amazon EC2 does not fulfill requests in pools where the maximum price you're willing to pay for Spot Instances is less than the Spot price or the Spot price is greater than the price for On-Demand Instances.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "FulfilledCapacity",
+      "namespace": "AWS/EC2Spot"
+    },
+    "description": "The capacity that Amazon EC2 has fulfilled.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "MaxPercentCapacityAllocation",
+      "namespace": "AWS/EC2Spot"
+    },
+    "description": "The maximum value of `PercentCapacityAllocation` across all fleet pools specified in the fleet request.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "PendingCapacity",
+      "namespace": "AWS/EC2Spot"
+    },
+    "description": "The difference between `TargetCapacity` and `FulfilledCapacity`.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PercentCapacityAllocation",
+      "namespace": "AWS/EC2Spot"
+    },
+    "description": "The capacity allocated for the Spot capacity pool for the specified dimensions. To get the maximum value recorded across all Spot capacity pools, use `MaxPercentCapacityAllocation`.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "TargetCapacity",
+      "namespace": "AWS/EC2Spot"
+    },
+    "description": "The target capacity of the fleet request.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "TerminatingCapacity",
+      "namespace": "AWS/EC2Spot"
+    },
+    "description": "The capacity that is being terminated because the provisioned capacity is greater than the target capacity.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "Invocations",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of times that your function code is invoked, including successful invocations and invocations that result in a function error. Invocations aren't recorded if the invocation request is throttled or otherwise results in an invocation error. The value of `Invocations` equals the number of requests billed.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "Errors",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of invocations that result in a function error. Function errors include exceptions that your code throws and exceptions that the Lambda runtime throws. The runtime returns errors for issues such as timeouts and configuration errors. To calculate the error rate, divide the value of `Errors` by the value of `Invocations`. Note that the timestamp on an error metric reflects when the function was invoked, not when the error occurred.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects high error counts. Errors includes the exceptions thrown by the code as well as exceptions thrown by the Lambda runtime. You can check the logs related to the function to diagnose the issue.",
+        "threshold": {
+          "justification": "Set the threshold to a number greater than zero. The exact value can depend on the tolerance for errors in your application. Understand the criticality of the invocations that the function is handling. For some applications, any error might be unacceptable, while other applications might allow for a certain margin of error."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "FunctionName"
+          }
+        ],
+        "intent": "The alarm helps detect high error counts in function invocations."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "DeadLetterErrors",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "For [asynchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html), the number of times that Lambda attempts to send an event to a dead-letter queue (DLQ) but fails. Dead-letter errors can occur due to incorrectly set resources or size limits.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DestinationDeliveryFailures",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "For asynchronous invocation and supported [event source mappings](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html), the number of times that Lambda attempts to send an event to a [destination](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async-retain-records.html#invocation-async-destinations) but fails. For event source mappings, Lambda supports destinations for stream sources (DynamoDB and Kinesis). Delivery errors can occur due to permissions errors, incorrectly configured resources, or size limits. Errors can also occur if the destination you have configured is an unsupported type such as an Amazon SQS FIFO queue or an Amazon SNS FIFO topic.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "Throttles",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of invocation requests that are throttled. When all function instances are processing requests and no concurrency is available to scale up, Lambda rejects additional requests with a `TooManyRequestsException` error. Throttled requests and other invocation errors don't count as either `Invocations` or `Errors`.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects a high number of throttled invocation requests. Throttling occurs when there is no concurrency is available for scale up. There are several approaches to resolve this issue. 1) Request a concurrency increase from AWS Support in this Region. 2) Identify performance issues in the function to improve the speed of processing and therefore improve throughput. 3) Increase the batch size of the function, so that more messages are processed by each function invocation.",
+        "threshold": {
+          "justification": "Set the threshold to a number greater than zero. The exact value of the threshold can depend on the tolerance of the application. Set the threshold according to its usage and scaling requirements of the function."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "FunctionName"
+          }
+        ],
+        "intent": "The alarm helps detect a high number of throttled invocation requests for a Lambda function. It is important to know if requests are constantly getting rejected due to throttling and if you need to improve Lambda function performance or increase concurrency capacity to avoid constant throttling."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ProvisionedConcurrencyInvocations",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of times that your function code is invoked using [provisioned concurrency](https://docs.aws.amazon.com/lambda/latest/dg/provisioned-concurrency.html).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ProvisionedConcurrencySpilloverInvocations",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of times that your function code is invoked using standard concurrency when all provisioned concurrency is in use.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "RecursiveInvocationsDropped",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of times that Lambda has stopped invocation of your function because it has detected that your function is part of an infinite recursive loop. Recursive loop detection monitors how many times a function is invoked as part of a chain of requests by tracking metadata added by supported AWS SDKs. By default, if your function is invoked as part of a chain of requests approximately 16 times, Lambda drops the next invocation. If you disable recursive loop detection, this metric is not emitted. For more information about this feature, see [Use Lambda recursive loop detection to prevent infinite loops](https://docs.aws.amazon.com/lambda/latest/dg/invocation-recursion.html).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "Duration",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The amount of time that your function code spends processing an event. The billed duration for an invocation is the value of `Duration` rounded up to the nearest millisecond. `Duration` does not include cold start time.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Milliseconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects long duration times for processing an event by a Lambda function. Long durations might be because of changes in function code making the function take longer to execute, or the function's dependencies taking longer.",
+        "threshold": {
+          "justification": "The threshold for the duration depends on your application and workloads and your performance requirements. For high-performance requirements, set the threshold to a shorter time to see if the function is meeting expectations. You can also analyze historical data for duration metrics to see the if the time taken matches the performance expectation of the function, and then set the threshold to a longer time than the historical average. Make sure to set the threshold lower than the configured function timeout."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "p90",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "FunctionName"
+          }
+        ],
+        "intent": "This alarm can detect a long running duration of a Lambda function. High runtime duration indicates that a function is taking a longer time for invocation, and can also impact the concurrency capacity of invocation if Lambda is handling a higher number of events. It is critical to know if the Lambda function is constantly taking longer execution time than expected."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "PostRuntimeExtensionsDuration",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The cumulative amount of time that the runtime spends running code for extensions after the function code has completed.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "IteratorAge",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "For DynamoDB, Kinesis, and Amazon DocumentDB event sources, the age of the last record in the event in milliseconds. This metric measures the time between when a stream receives the record and when the event source mapping sends the event to the function.",
+    "recommendedStatistics": "Average, Maximum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "OffsetLag",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "For self-managed Apache Kafka and Amazon Managed Streaming for Apache Kafka (Amazon MSK) event sources, the difference in offset between the last record written to a topic and the last record that your function's consumer group processed. Though a Kafka topic can have multiple partitions, this metric measures the offset lag at the topic level.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ConcurrentExecutions",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of function instances that are processing events. If this number reaches your [concurrent executions quota](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html#compute-and-storage) for the Region, or the [reserved concurrency](https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html) limit on the function, then Lambda throttles additional invocation requests.",
+    "recommendedStatistics": "Maximum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor if the concurrency of the function is approaching the Region-level concurrency limit of your account. A function starts to be throttled if it reaches the concurrency limit. You can take the following actions to avoid throttling. 1) Request a concurrency increase from AWS Support in this Region. 2) Identify performance issues in the function to improve the speed of processing and therefore improve throughput. 3) Increase the batch size of the function, so that more messages are processed by each function invocation. To get better visibility on reserved concurrency and provisioned concurrency utilization, set an alarm on the new metric ClaimedAccountConcurrency instead.",
+        "threshold": {
+          "justification": "Set the threshold to about 90% of the concurrency quota set for the account in the Region. By default, your account has a concurrency quota of 1,000 across all functions in a Region. However, you can check the quota of your account, as it can be increased by contacting AWS support."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "FunctionName"
+          }
+        ],
+        "intent": "This alarm can proactively detect if the concurrency of the function is approaching the Region-level concurrency quota of your account, so that you can act on it. A function is throttled if it reaches the Region-level concurrency quota of the account."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ProvisionedConcurrentExecutions",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of function instances that are processing events using [provisioned concurrency](https://docs.aws.amazon.com/lambda/latest/dg/provisioned-concurrency.html). For each invocation of an alias or version with provisioned concurrency, Lambda emits the current count. If your function is inactive or not receiving requests, Lambda doesn't emit this metric.",
+    "recommendedStatistics": "Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ProvisionedConcurrencyUtilization",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "For a version or alias, the value of `ProvisionedConcurrentExecutions` divided by the total amount of provisioned concurrency configured. For example, if you configure a provisioned concurrency of 10 for your function, and your `ProvisionedConcurrentExecutions` is 7, then your `ProvisionedConcurrencyUtilization` is 0.7. If your function is inactive or not receiving requests, Lambda doesn't emit this metric because it is based on `ProvisionedConcurrentExecutions`. Keep this in mind if you use `ProvisionedConcurrencyUtilization` as the basis for CloudWatch alarms.",
+    "recommendedStatistics": "Maximum, Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "UnreservedConcurrentExecutions",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "For a Region, the amount of concurrency that is unavailable for on-demand invocations. `ClaimedAccountConcurrency` is equal to `UnreservedConcurrentExecutions` plus the amount of allocated concurrency (i.e. the total reserved concurrency plus total provisioned concurrency). For more information, see [Working with the ClaimedAccountConcurrency metric](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-concurrency.html#claimed-account-concurrency).",
+    "recommendedStatistics": "Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AsyncEventsReceived",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of events that Lambda successfully queues for processing. This metric provides insight into the number of events that a Lambda function receives. Monitor this metric and set alarms for thresholds to check for issues. For example, to detect an undesirable number of events sent to Lambda, and to quickly diagnose issues resulting from incorrect trigger or function configurations. Mismatches between `AsyncEventsReceived` and `Invocations` can indicate a disparity in processing, events being dropped, or a potential queue backlog.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AsyncEventAge",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The time between when Lambda successfully queues the event and when the function is invoked. The value of this metric increases when events are being retried due to invocation failures or throttling. Monitor this metric and set alarms for thresholds on different statistics for when a queue buildup occurs. To troubleshoot an increase in this metric, look at the `Errors` metric to identify function errors and the `Throttles` metric to identify concurrency issues.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "AsyncEventsDropped",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of events that are dropped without successfully executing the function. If you configure a dead-letter queue (DLQ) or `OnFailure` destination, then events are sent there before they're dropped. Events are dropped for various reasons. For example, events can exceed the maximum event age or exhaust the maximum retry attempts, or reserved concurrency might be set to 0. To troubleshoot why events are dropped, look at the `Errors` metric to identify function errors and the `Throttles` metric to identify concurrency issues.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "OversizedRecordCount",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "For Amazon DocumentDB event sources, the number of events your function receives from your change stream that are over 6 MB in size. Lambda drops the message and emits this metric.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ClaimedAccountConcurrency",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "For a Region, the amount of concurrency that is unavailable for on-demand invocations. `ClaimedAccountConcurrency` is equal to `UnreservedConcurrentExecutions` plus the amount of allocated concurrency (i.e. the total reserved concurrency plus total provisioned concurrency). For more information, see [Working with the ClaimedAccountConcurrency metric](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-concurrency.html#claimed-account-concurrency).",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor if the concurrency of your Lambda functions is approaching the Region-level concurrency limit of your account. A function starts to be throttled if it reaches the concurrency limit. You can take the following actions to avoid throttling. 1) [Request a concurrency increase](https://repost.aws/knowledge-center/lambda-concurrency-limit-increase) in this Region. 2) Identify and reduce any unused reserved concurrency or provisioned concurrency. 3) Identify performance issues in the functions to improve the speed of processing and therefore improve throughput. 4) Increase the batch size of the functions, so that more messages are processed by each function invocation.",
+        "threshold": {
+          "justification": "You should calculate the value of about 90% of the concurrency quota set for the account in the Region, and use the result as the threshold value. By default, your account has a concurrency quota of 1,000 across all functions in a Region. However, you should check the quota of your account from the Service Quotas dashboard."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "notBreaching",
+        "dimensions": [],
+        "intent": "This alarm can proactively detect if the concurrency of your Lambda functions is approaching the Region-level concurrency quota of your account, so that you can act on it. Functions are throttled if ClaimedAccountConcurrency reaches the Region-level concurrency quota of the account. If you are using Reserved Concurrency (RC) or Provisioned Concurrency (PC), this alarm gives you more visibility on concurrency utilization than an alarm on ConcurrentExecutions would."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "PolledEventCount",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of events that Lambda reads successfully from the event source. If Lambda polls for events but receives an empty poll (no new records), Lambda emits a 0 value for this metric. Use this metric to detect whether your event source mapping is correctly polling for new events."
+  },
+  {
+    "metricId": {
+      "metricName": "FilteredOutEventCount",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "For event source mapping with a [filter criteria](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html), the number of events filtered out by that filter criteria. Use this metric to detect whether your event source mapping is properly filtering out events. For events that match the filter criteria, Lambda emits a 0 metric."
+  },
+  {
+    "metricId": {
+      "metricName": "InvokedEventCount",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of events that invoked your Lambda function. Use this metric to verify that events are properly invoking your function. If an event results in a function error or throttling, `InvokedEventCount` may count multiple times for the same polled event due to automatic retries."
+  },
+  {
+    "metricId": {
+      "metricName": "FailedInvokeEventCount",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of events that Lambda tried to invoke your function with, but failed. Invocations can fail due to reasons such as network configuration issues, incorrect permissions, or a deleted Lambda function, version, or alias. If your event source mapping has [partial batch responses](https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-errorhandling.html#services-sqs-batchfailurereporting) enabled, `FailedInvokeEventCount` includes any event with a non-empty `BatchItemFailures` in the response. Note: The timestamp for the `FailedInvokeEventCount` metric represents the end of the function invocation. This behavior differs from other Lambda invocation error metrics, which are timestamped at the start of the function invocation."
+  },
+  {
+    "metricId": {
+      "metricName": "DroppedEventCount",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of events that Lambda dropped due to expiry or retry exhaustion. Specifically, this is the number of records that exceed your configured values for `MaximumRecordAgeInSeconds` or `MaximumRetryAttempts`. Importantly, this doesn't include the number of records that expire due to exceeding your event source's retention settings. Dropped events also excludes events that you send to an [on-failure destination](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async-retain-records.html). Use this metric to detect an increasing backlog of events."
+  },
+  {
+    "metricId": {
+      "metricName": "OnFailureDestinationDeliveredEventCount",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "For event source mappings with an [on-failure destination](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async-retain-records.html) configured, the number of events sent to that destination. Use this metric to monitor for function errors related to invocations from this event source. If delivery to the destination fails, Lambda handles metrics as follows: Lambda doesn't emit the `OnFailureDestinationDeliveredEventCount` metric. For the `DestinationDeliveryFailures` metric, Lambda emits a 1. For the `DroppedEventCount` metric, Lambda emits a number equal to the number of events that failed delivery."
+  },
+  {
+    "metricId": {
+      "metricName": "DeletedEventCount",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "The number of events that Lambda successfully deletes after processing. If Lambda tries to delete an event but fails, Lambda emits a 0 metric. Use this metric to ensure that successfully processed events are deleted from your event source."
+  },
+  {
+    "metricId": {
+      "metricName": "ProvisionedPollers",
+      "namespace": "AWS/Lambda"
+    },
+    "description": "For event source mappings in provisioned mode, the number of event pollers that are actively running. View this metric using the `MAX` metric."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupMinSize",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The minimum size of the Auto Scaling group. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupMaxSize",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The maximum size of the Auto Scaling group. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupDesiredCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The number of instances that the Auto Scaling group attempts to maintain. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupInServiceInstances",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The number of instances that are running as part of the Auto Scaling group. This metric does not include instances that are pending or terminating. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupPendingInstances",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The number of instances that are pending. A pending instance is not yet in service. This metric does not include instances that are in service or terminating. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupStandbyInstances",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The number of instances that are in a `Standby` state. Instances in this state are still running but are not actively in service. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupTerminatingInstances",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The number of instances that are in the process of terminating. This metric does not include instances that are in service, pending, or returning to a warm pool after Auto Scaling group scale in. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupTotalInstances",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The total number of instances in the Auto Scaling group. This metric identifies the number of instances that are in service, pending, and terminating. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupInServiceCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The number of capacity units that are running as part of the Auto Scaling group. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit.",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect when the capacity in the group is below the desired capacity required for your workload. To troubleshoot, check your scaling activities for launch failures and confirm that your desired capacity configuration is correct.",
+        "threshold": {
+          "justification": "The threshold value should be the minimum capacity required to run your workload. In most cases, you can set this to match the GroupDesiredCapacity metric."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "AutoScalingGroupName"
+          }
+        ],
+        "intent": "This alarm can detect a low availability in your auto scaling group because of launch failures or suspended launches."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "GroupPendingCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The number of capacity units that are pending. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupStandbyCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The number of capacity units that are in a `Standby` state. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupTerminatingCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The number of capacity units that are in the process of terminating. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupTotalCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The total number of capacity units in the Auto Scaling group. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "WarmPoolMinSize",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The minimum size of the warm pool. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "WarmPoolDesiredCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The amount of capacity that Amazon EC2 Auto Scaling attempts to maintain in the warm pool. This is equivalent to the maximum size of the Auto Scaling group minus its desired capacity, or, if set, as the maximum prepared capacity of the Auto Scaling group minus its desired capacity. However, when the minimum size of the warm pool is equal to or greater than the difference between the maximum size (or, if set, the maximum prepared capacity) and the desired capacity of the Auto Scaling group, then the warm pool desired capacity will be equivalent to the `WarmPoolMinSize`. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "WarmPoolPendingCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The amount of capacity in the warm pool that is pending. This includes instances returning to a warm pool after Auto Scaling group scale in. This metric does not include instances that are running, stopped, or terminating. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "WarmPoolTerminatingCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The amount of capacity in the warm pool that is in the process of terminating. This metric does not include instances that are running, stopped, or pending. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "WarmPoolWarmedCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The amount of capacity available to enter the Auto Scaling group during scale out. This metric does not include instances that are pending or terminating. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "WarmPoolTotalCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The total capacity of the warm pool, including instances that are running, stopped, pending, or terminating. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupAndWarmPoolDesiredCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The desired capacity of the Auto Scaling group and the warm pool combined. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "GroupAndWarmPoolTotalCapacity",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The total capacity of the Auto Scaling group and the warm pool combined. This includes instances that are running, stopped, pending, terminating, or in service. Reporting criteria: Reported if metrics collection is enabled.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "PredictiveScalingLoadForecast",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The amount of load that's anticipated to be generated by your application. Reporting criteria: Reported after the initial forecast is created.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The unit of this metric represents the unit of the selected metric pair in the predictive scaling policy but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "PredictiveScalingCapacityForecast",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The anticipated amount of capacity needed to meet application demand. This is based on the load forecast and target utilization level at which you want to maintain your Auto Scaling instances. Reporting criteria: Reported after the initial forecast is created.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "The metric represents a Count but uses None for the CloudWatch unit."
+  },
+  {
+    "metricId": {
+      "metricName": "PredictiveScalingMetricPairCorrelation",
+      "namespace": "AWS/AutoScaling"
+    },
+    "description": "The correlation between the scaling metric and the per-instance average of the load metric. Predictive scaling assumes high correlation. Therefore, if you observe low value for this metric, it's better not to use a metric pair. Reporting criteria: Reported after the initial forecast is created.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_total_time",
+      "namespace": "LambdaInsights"
+    },
+    "description": "Sum of `cpu_system_time` and `cpu_user_time`.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "init_duration",
+      "namespace": "LambdaInsights"
+    },
+    "description": "The amount of time spent in the `init` phase of the Lambda execution environment lifecycle.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "memory_utilization",
+      "namespace": "LambdaInsights"
+    },
+    "description": "The maximum memory measured as a percentage of the memory allocated to the function.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm is used to detect if the memory utilization of a lambda function is approaching the configured limit. For troubleshooting, you can try to 1) Optimize your code. 2) Rightly size your memory allocation by accurately estimating the memory requirements. You can refer to [Lambda Power Tuning](https://docs.aws.amazon.com/lambda/latest/operatorguide/profile-functions.html) for the same. 3) Use connection pooling. Refer to [Using Amazon RDS Proxy with AWS Lambda](https://aws.amazon.com/blogs/compute/using-amazon-rds-proxy-with-aws-lambda/) for the connection pooling for RDS database. 4) You can also consider designing your functions to avoid storing large amounts of data in memory between invocations.",
+        "threshold": {
+          "staticValue": 90.0,
+          "justification": "Set the threshold to 90% to get an alert when memory utilization exceeds 90% of the allocated memory. You can adjust this to a lower value if you have a concern for the workload for memory utilization. You can also check the historical data for this metric and set the threshold accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "function_name"
+          }
+        ],
+        "intent": "This alarm is used to detect if the memory utilization for the Lambda function is approaching the configured limit."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "rx_bytes",
+      "namespace": "LambdaInsights"
+    },
+    "description": "The number of bytes received by the function.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "tx_bytes",
+      "namespace": "LambdaInsights"
+    },
+    "description": "The number of bytes sent by the function.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "total_memory",
+      "namespace": "LambdaInsights"
+    },
+    "description": "The amount of memory allocated to your Lambda function. This is the same as your function’s memory size.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Megabytes"
+  },
+  {
+    "metricId": {
+      "metricName": "total_network",
+      "namespace": "LambdaInsights"
+    },
+    "description": "Sum of `rx_bytes` and `tx_bytes`. Even for functions that don't perform I/O tasks, this value is usually greater than zero because of network calls made by the Lambda runtime.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "used_memory_max",
+      "namespace": "LambdaInsights"
+    },
+    "description": "The measured memory of the function sandbox.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Megabytes"
+  },
+  {
+    "metricId": {
+      "metricName": "tmp_used",
+      "namespace": "LambdaInsights"
+    },
+    "description": "The amount of space used in the `/tmp` directory.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "CommitQueueLength",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The number of transactions waiting to commit at a given point in time.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ConcurrencyScalingActiveClusters",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The number of concurrency scaling clusters that are actively processing queries at any given time.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ConcurrencyScalingSeconds",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The number of seconds used by concurrency scaling clusters that have active query processing activity.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUUtilization",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The percentage of CPU utilization. For clusters, this metric represents an aggregation of all nodes (leader and compute) CPU utilization values.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "DatabaseConnections",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The number of database connections to a cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "HealthStatus",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "Indicates the health of the cluster. Every minute the cluster connects to its database and performs a simple query. If it is able to perform this operation successfully, the cluster is considered healthy. Otherwise, the cluster is unhealthy. An unhealthy status can occur when the cluster database is under extremely heavy load or if there is a configuration problem with a database on the cluster. Note: In Amazon CloudWatch, this metric is reported as 1 or 0 whereas in the Amazon Redshift console, this metric is displayed with the words `HEALTHY` or `UNHEALTHY` for convenience. When this metric is displayed in the Amazon Redshift console, sampling averages are ignored and only `HEALTHY` or `UNHEALTHY` are displayed. In Amazon CloudWatch, values different than 1 and 0 might occur because of sampling issue. Any value below 1 for `HealthStatus` is reported as 0 (`UNHEALTHY`).",
+    "recommendedStatistics": "Average, Minimum",
+    "unitInfo": "Count (1/0) (HEALTHY/UNHEALTHY in the Amazon Redshift console)"
+  },
+  {
+    "metricId": {
+      "metricName": "MaintenanceMode",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "Indicates whether the cluster is in maintenance mode. Note: In Amazon CloudWatch, this metric is reported as 1 or 0 whereas in the Amazon Redshift console, this metric is displayed with the words `ON` or `OFF` for convenience. When this metric is displayed in the Amazon Redshift console, sampling averages are ignored and only `ON` or `OFF` are displayed. In Amazon CloudWatch, values different than 1 and 0 might occur because of sampling issues. Any value greater than 0 for `MaintenanceMode` is reported as 1 (`ON`).",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Count (1/0) (ON/OFF in the Amazon Redshift console)."
+  },
+  {
+    "metricId": {
+      "metricName": "MaxConfiguredConcurrencyScalingClusters",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "Maximum number of concurrency scaling clusters configured from the parameter group. For more information, see [Amazon Redshift parameter groups](https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html).",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkReceiveThroughput",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The rate at which the node or cluster receives data.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes/Second (MB/s in the Amazon Redshift console)"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkTransmitThroughput",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The rate at which the node or cluster writes data.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes/Second (MB/s in the Amazon Redshift console)"
+  },
+  {
+    "metricId": {
+      "metricName": "PercentageDiskSpaceUsed",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The percent of disk space used.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "QueriesCompletedPerSecond",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The average number of queries completed per second. Reported in 5-minute intervals. This metric isn't supported on single-node clusters.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "QueryDuration",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The average amount of time to complete a query. Reported in 5-minute intervals. This metric isn't supported on single-node clusters.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "QueryRuntimeBreakdown",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The total time queries spent running by query stage. Reported in 5-minute intervals.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadIOPS",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The average number of disk read operations per second.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadLatency",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The average amount of time taken for disk read I/O operations.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadThroughput",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The average number of bytes read from disk per second.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes (GB/s in the Amazon Redshift console)"
+  },
+  {
+    "metricId": {
+      "metricName": "RedshiftManagedStorageTotalCapacity",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "Total managed storage capacity.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Megabytes"
+  },
+  {
+    "metricId": {
+      "metricName": "TotalTableCount",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The number of user tables open at a particular point in time. This total doesn't include Amazon Redshift Spectrum tables.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "WLMQueueLength",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The number of queries waiting to enter a workload management (WLM) queue.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "WLMQueueWaitTime",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The total time queries spent waiting in the workload management (WLM) queue. Reported in 5-minute intervals.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Milliseconds."
+  },
+  {
+    "metricId": {
+      "metricName": "WLMQueriesCompletedPerSecond",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The average number of queries completed per second for a workload management (WLM) queue. Reported in 5-minute intervals. This metric isn't supported on single-node clusters.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "WLMQueryDuration",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The average length of time to complete a query for a workload management (WLM) queue. Reported in 5-minute intervals. This metric isn't supported on single-node clusters.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "WLMRunningQueries",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The number of queries running from both the main cluster and concurrency scaling cluster per WLM queue.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteIOPS",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The average number of write operations per second.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteLatency",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The average amount of time taken for disk write I/O operations.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteThroughput",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The average number of bytes written to disk per second.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes (GB/s in the Amazon Redshift console)"
+  },
+  {
+    "metricId": {
+      "metricName": "SchemaQuota",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The configured quota for a schema. Periodic/Push: Periodic. Frequency: 5 minutes. Stop criteria: Schema dropped or quota removed.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Megabytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NumExceededSchemaQuotas",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The number of schemas with exceeded quotas. Periodic/Push: Periodic. Frequency: 5 minutes. Stop criteria: N/A.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "StorageUsed",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The disk or storage space used by a schema. Periodic/Push: Periodic. Frequency: 5 minutes. Stop criteria: Schema dropped or quota removed.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Megabytes"
+  },
+  {
+    "metricId": {
+      "metricName": "PercentageQuotaUsed",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "The percentage of disk or storage space used relative to the configured schema quota. Periodic/Push: Periodic. Frequency: 5 minutes. Stop criteria: Schema dropped or quota removed.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "UsageLimitAvailable",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "Depending on the FeatureType, UsageLimitAvailable returns the following: If the FeatureType is `CONCURRENCY_SCALING`, UsageLimitAvailable returns the total amount of time that can be used by concurrency scaling in 1-minute increments. If the FeatureType is `CROSS_REGION_DATASHARING`, UsageLimitAvailable returns the total amount of data that can be scanned in 1-TB increments. If the FeatureType is `SPECTRUM`, UsageLimitAvailable returns the total amount of data that can be scanned in 1-TB increments.",
+    "unitInfo": "Minutes or TBs"
+  },
+  {
+    "metricId": {
+      "metricName": "UsageLimitConsumed",
+      "namespace": "AWS/Redshift"
+    },
+    "description": "Depending on the FeatureType, UsageLimitConsumed returns the following: If the FeatureType is `CONCURRENCY_SCALING`, UsageLimitAvailable returns the total amount of time used by concurrency scaling in 1-minute increments. If the FeatureType is `CROSS_REGION_DATASHARING`, UsageLimitAvailable returns the total amount of data scanned in 1-TB increments. If the FeatureType is `SPECTRUM`, UsageLimitAvailable returns the total amount of data scanned in 1-TB increments.",
+    "unitInfo": "Minutes or TBs"
+  },
+  {
+    "metricId": {
+      "metricName": "ActiveConnections",
+      "namespace": "AWS/PrivateLinkEndpoints"
+    },
+    "description": "The number of concurrent active connections. This includes connections in the SYN_SENT and ESTABLISHED states. Reporting criteria: The endpoint received traffic during the one-minute period.",
+    "recommendedStatistics": "Average, Maximum, and Minimum.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesProcessed",
+      "namespace": "AWS/PrivateLinkEndpoints"
+    },
+    "description": "The number of bytes exchanged between endpoints and endpoint services, aggregated in both directions. This is the number of bytes billed to the owner of the endpoint. The bill displays this value in GB. Reporting criteria: The endpoint received traffic during the one-minute period.",
+    "recommendedStatistics": "Average, Sum, Maximum, and Minimum.",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NewConnections",
+      "namespace": "AWS/PrivateLinkEndpoints"
+    },
+    "description": "The number of new connections established through the endpoint. Reporting criteria: The endpoint received traffic during the one-minute period.",
+    "recommendedStatistics": "Average, Sum, Maximum, and Minimum.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PacketsDropped",
+      "namespace": "AWS/PrivateLinkEndpoints"
+    },
+    "description": "The number of packets dropped by the endpoint. This metric might not capture all packet drops. Increasing values could indicate that the endpoint or endpoint service is unhealthy. Reporting criteria: The endpoint received traffic during the one-minute period.",
+    "recommendedStatistics": "Average, Sum, and Maximum.",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect if the endpoint or endpoint service is unhealthy by monitoring the number of packets dropped by the endpoint. Note that packets larger than 8500 bytes that arrive at the VPC endpoint are dropped. For troubleshooting, see [connectivity problems between an interface VPC endpoint and an endpoint service](https://repost.aws/knowledge-center/connect-endpoint-service-vpc).",
+        "threshold": {
+          "justification": "Set the threshold according to the use case. If you want to be aware of the unhealthy status of the endpoint or endpoint service, you should set the threshold low so that you get a chance to fix the issue before a huge data loss. You can use historical data to understand the tolerance for dropped packets and set the threshold accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "VPC Id"
+          },
+          {
+            "name": "VPC Endpoint Id"
+          },
+          {
+            "name": "Endpoint Type"
+          },
+          {
+            "name": "Subnet Id"
+          },
+          {
+            "name": "Service Name"
+          }
+        ],
+        "intent": "This alarm is used to detect if the endpoint or endpoint service is unhealthy."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "RstPacketsReceived",
+      "namespace": "AWS/PrivateLinkEndpoints"
+    },
+    "description": "The number of RST packets received by the endpoint. Increasing values could indicate that the endpoint service is unhealthy. Reporting criteria: The endpoint received traffic during the one-minute period.",
+    "recommendedStatistics": "Average, Sum, and Maximum.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ActiveConnectionCount",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The total number of concurrent active TCP connections through the NAT gateway. A value of zero indicates that there are no active connections through the NAT gateway.",
+    "recommendedStatistics": "Maximum, Average, Minimum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesInFromDestination",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of bytes received by the NAT gateway from the destination. If the value for `BytesOutToSource` is less than the value for `BytesInFromDestination`, there might be data loss during NAT gateway processing, or traffic being actively blocked by the NAT gateway.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesInFromSource",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of bytes received by the NAT gateway from clients in your VPC. If the value for `BytesOutToDestination` is less than the value for `BytesInFromSource`, there might be data loss during NAT gateway processing.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesOutToDestination",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of bytes sent out through the NAT gateway to the destination. A value greater than zero indicates that there is traffic going to the internet from clients that are behind the NAT gateway. If the value for `BytesOutToDestination` is less than the value for `BytesInFromSource`, there might be data loss during NAT gateway processing.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesOutToSource",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of bytes sent through the NAT gateway to the clients in your VPC. A value greater than zero indicates that there is traffic coming from the internet to clients that are behind the NAT gateway. If the value for `BytesOutToSource` is less than the value for `BytesInFromDestination`, there might be data loss during NAT gateway processing, or traffic being actively blocked by the NAT gateway.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ConnectionAttemptCount",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of connection attempts made through the NAT gateway. This includes only the initial SYN. In some cases, `ConnectionAttemptCount` may be lower than `ConnectionEstablishedCount` due to SYN retransmission. If the value for `ConnectionEstablishedCount` is less than the value for `ConnectionAttemptCount`, this indicates that clients behind the NAT gateway attempted to establish new connections for which there was no response.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ConnectionEstablishedCount",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of connections established through the NAT gateway. This includes SYN and SYN retransmissions. If the value for `ConnectionEstablishedCount` is less than the value for `ConnectionAttemptCount`, this indicates that clients behind the NAT gateway attempted to establish new connections for which there was no response.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ErrorPortAllocation",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of times the NAT gateway could not allocate a source port. A value greater than zero indicates that too many concurrent connections are open through the NAT gateway.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect when the NAT Gateway is unable to allocate ports to new connections. To resolve this issue, see [Resolve port allocation errors on NAT Gateway.](https://repost.aws/knowledge-center/vpc-resolve-port-allocation-errors)",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "If the value of ErrorPortAllocation is greater than zero, that means too many concurrent connections to a single popular destination are open through NATGateway."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "NatGatewayId"
+          }
+        ],
+        "intent": "This alarm is used to detect if the NAT gateway could not allocate a source port."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "IdleTimeoutCount",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of connections that transitioned from the active state to the idle state. An active connection transitions to idle if it was not closed gracefully and there was no activity for the last 350 seconds. A value greater than zero indicates that there are connections that have been moved to an idle state. If the value for `IdleTimeoutCount` increases, it might indicate that clients behind the NAT gateway are re-using stale connections.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PacketsDropCount",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of packets dropped by the NAT gateway. To calculate the number of dropped packets as a percentage of the overall packet traffic, use this formula: `PacketsDropCount/(PacketsInFromSource+PacketsInFromDestination)*100`. If this value exceeds 0.01 percent of the total traffic on the NAT gateway, there may be an issue with Amazon VPC service. Use the [AWS service health dashboard](http://status.aws.amazon.com/) to identify any issues with the service that may be causing NAT gateways to drop packets.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect when packets are dropped by NAT Gateway. This might happen because of an issue with NAT Gateway, so check [AWS service health dashboard](https://health.aws.amazon.com/health/status) for the status of AWS NAT Gateway in your Region. This can help you correlate the network issue related to traffic using NAT gateway.",
+        "threshold": {
+          "justification": "You should calculate the value of 0.01 percent of the total traffic on the NAT Gateway and use that result as the threshold value. Use historical data of the traffic on NAT Gateway to determine the threshold."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "NatGatewayId"
+          }
+        ],
+        "intent": "This alarm is used to detect if packets are being dropped by NAT Gateway."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "PacketsInFromDestination",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of packets received by the NAT gateway from the destination. If the value for `PacketsOutToSource` is less than the value for `PacketsInFromDestination`, there might be data loss during NAT gateway processing, or traffic being actively blocked by the NAT gateway.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PacketsInFromSource",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of packets received by the NAT gateway from clients in your VPC. If the value for `PacketsOutToDestination` is less than the value for `PacketsInFromSource`, there might be data loss during NAT gateway processing.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PacketsOutToDestination",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of packets sent out through the NAT gateway to the destination. A value greater than zero indicates that there is traffic going to the internet from clients that are behind the NAT gateway. If the value for `PacketsOutToDestination` is less than the value for `PacketsInFromSource`, there might be data loss during NAT gateway processing.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PacketsOutToSource",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "The number of packets sent through the NAT gateway to the clients in your VPC. A value greater than zero indicates that there is traffic coming from the internet to clients that are behind the NAT gateway. If the value for `PacketsOutToSource` is less than the value for `PacketsInFromDestination`, there might be data loss during NAT gateway processing, or traffic being actively blocked by the NAT gateway.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PeakPacketsPerSecond",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "This metric calculates the average packet rate (packets processed per second) every 10 seconds for 60 seconds and then reports the maximum of the six rates (the highest average packet rate).",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PeakBytesPerSecond",
+      "namespace": "AWS/NATGateway"
+    },
+    "description": "This metric reports the highest 10-second bytes per second average in a given minute.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "TimeSinceLastSync",
+      "namespace": "AWS/EFS"
+    },
+    "description": "Shows the amount of time that has passed since the last successful sync to the destination file system in a replication configuration. Any changes to data on the source file system that occurred before the `TimeSinceLastSync` value have been successfully replicated. Any changes on the source that occurred after `TimeSinceLastSync` might not be fully replicated. `FileSystemId` dimension – ID of the source file system in the replication configuration. `DestinationFileSystemId` dimension – ID of the destination file system in the replication configuration.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "PercentIOLimit",
+      "namespace": "AWS/EFS"
+    },
+    "description": "Shows how close a file system is to reaching the I/O limit of the General Purpose performance mode.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps in ensuring that the workload stays within the I/O limit available to the file system. If the metric reaches its I/O limit consistently, consider moving the application to a file system that uses Max I/O performance as mode. For troubleshooting, check clients that are connected to the file system and applications of the clients that throttles the file system.",
+        "threshold": {
+          "staticValue": 100.0,
+          "justification": "When the file system reaches its I/O limit, it may respond to read and write requests slower. Therefore, it is recommended that the metric is monitored to avoid impacting applications that use the file system. The threshold can be set around 100%. However, this value can be adjusted to a lower value based on file system characteristics."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "FileSystemId"
+          }
+        ],
+        "intent": "This alarm is used to detect how close the file system is to reach the I/O limit of the General Purpose performance mode. Consistent high I/O percentage can be an indicator of the file system cannot scale with respect to I/O requests enough and the file system can be a resource bottleneck for the applications that use the file system."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "BurstCreditBalance",
+      "namespace": "AWS/EFS"
+    },
+    "description": "The number of burst credits that a file system has. Burst credits allow a file system to burst to throughput levels above a file system’s baseline level for periods of time. The Minimum statistic is the smallest burst credit balance for any minute during the period. The Maximum statistic is the largest burst credit balance for any minute during the period. The Average statistic is the average burst credit balance during the period.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps in ensuring that there is available burst credit balance for the file system usage. When there is no available burst credit, applications access to the the file system will be limited due to low throughput. If the metric drops to 0 consistently, consider changing the throughput mode to [Elastic or Provisioned throughput mode](https://docs.aws.amazon.com/efs/latest/ug/performance.html#throughput-modes).",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "When the file system run out of burst credits and even if the baseline throughput rate is lower, EFS continues to provide a metered throughput of 1 MiBps to all file systems. However, it is recommended that the metric is monitored for low burst credit balance to avoid the file system acting as resource bottleneck for the applications. The threshold can be set around 0 bytes."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanOrEqualToThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "FileSystemId"
+          }
+        ],
+        "intent": "This alarm is used to detect low burst credit balance of the file system. Consistent low burst credit balance can be an indicator of the slowing down in throughput and increase in I/O latency."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "PermittedThroughput",
+      "namespace": "AWS/EFS"
+    },
+    "description": "The maximum amount of throughput that a file system can drive. For file systems using Elastic throughput, this value reflects the maximum write throughput of the file system. For file systems using Provisioned throughput, if the amount of data stored in the EFS Standard storage class allows your file system to drive a higher throughput than you provisioned, this metric reflects the higher throughput instead of the provisioned amount. For file systems in Bursting throughput, this value is a function of the file system size and `BurstCreditBalance`. The Minimum statistic is the smallest throughput permitted for any minute during the period. The Maximum statistic is the highest throughput permitted for any minute during the period. The Average statistic is the average throughput permitted during the period. Note: Read operations are metered at one-third the rate of other operations.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "MeteredIOBytes",
+      "namespace": "AWS/EFS"
+    },
+    "description": "The number of metered bytes for each file system operation, including data read, data write, and metadata operations, with read operations discounted according to the throughput limit. You can create a [CloudWatch metric math expression](https://docs.aws.amazon.com/efs/latest/ug/monitoring-metric-math.html#metric-math-throughput-utilization) that compares `MeteredIOBytes` to `PermittedThroughput`. If these values are equal, then you are consuming the entire amount of throughput allocated to your file system. In this situation, you might consider changing the file system's throughput mode to get higher throughput. The Sum statistic is the total number of metered bytes associated with all file system operations. The Minimum statistic is the size of the smallest operation during the period. The Maximum statistic is the size of the largest operation during the period. The Average statistic is the average size of an operation during the period. The SampleCount statistic provides a count of all operations.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, SampleCount",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "TotalIOBytes",
+      "namespace": "AWS/EFS"
+    },
+    "description": "The actual number of bytes for each file system operation processed by Amazon EFS, without any read discounts. This number may differ from the actual amount requested by your applications because it includes minimums. This number may also be higher than the numbers shown in `PermittedThroughput`. Data operations are metered at 32 KiB and other operations are metered at 4 KiB. After the minimum, all operations are metered per KiB. The Sum statistic is the total number of bytes associated with all file system operations. The Minimum statistic is the size of the smallest operation during the period. The Maximum statistic is the size of the largest operation during the period. The Average statistic is the average size of an operation during the period. The SampleCount statistic provides a count of all operations. Note: To calculate the average operations per second for a period, divide the SampleCount statistic by the number of seconds in the period. To calculate the average throughput (bytes per second) for a period, divide the Sum statistic by the number of seconds in the period.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, SampleCount",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "DataReadIOBytes",
+      "namespace": "AWS/EFS"
+    },
+    "description": "The actual number of bytes for each file system operation processed by Amazon EFS, without any read discounts. This number may differ from the actual amount requested by your applications because it includes minimums. This number may also be higher than the numbers shown in `PermittedThroughput`. Data operations are metered at 32 KiB and other operations are metered at 4 KiB. After the minimum, all operations are metered per KiB. The Sum statistic is the total number of bytes associated with all file system operations. The Minimum statistic is the size of the smallest operation during the period. The Maximum statistic is the size of the largest operation during the period. The Average statistic is the average size of an operation during the period. The SampleCount statistic provides a count of all operations. Note: To calculate the average operations per second for a period, divide the SampleCount statistic by the number of seconds in the period. To calculate the average throughput (bytes per second) for a period, divide the Sum statistic by the number of seconds in the period.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, SampleCount",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "DataWriteIOBytes",
+      "namespace": "AWS/EFS"
+    },
+    "description": "The actual number of bytes for each file system read operation. The Sum statistic is the total number of bytes associated with read operations. The Minimum statistic is the size of the smallest read operation during the period. The Maximum statistic is the size of the largest read operation during the period. The Average statistic is the average size of read operations during the period. The SampleCount statistic provides a count of read operations.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, SampleCount",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "MetadataIOBytes",
+      "namespace": "AWS/EFS"
+    },
+    "description": "The actual number of bytes for each file system write operation. The Sum statistic is the total number of bytes associated with write operations. The Minimum statistic is the size of the smallest write operation during the period. The Maximum statistic is the size of the largest write operation during the period. The Average statistic is the average size of write operations during the period. The SampleCount statistic provides a count of write operations.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, SampleCount",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ClientConnections",
+      "namespace": "AWS/EFS"
+    },
+    "description": "The actual number of bytes for each metadata write operation. The Sum statistic is the total number of bytes associated with metadata write operations. The Minimum statistic is the size of the smallest metadata write operation during the period. The Maximum statistic is the size of the largest metadata write operation during the period. The Average statistic is the average size of metadata write operations during the period. The SampleCount statistic provides a count of metadata write operations.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, SampleCount",
+    "unitInfo": "Count of client connections"
+  },
+  {
+    "metricId": {
+      "metricName": "StorageBytes",
+      "namespace": "AWS/EFS"
+    },
+    "description": "The number of client connections to a file system. When using a standard client, there is one connection per mounted Amazon EC2 instance. Note: To calculate the average `ClientConnections` for periods greater than one minute, divide the Sum statistic by the number of minutes in the period.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count of client connections"
+  },
+  {
+    "metricId": {
+      "metricName": "MetadataReadIOBytes",
+      "namespace": "AWS/EFS"
+    },
+    "description": "The actual number of bytes for each metadata operation. The Sum statistic is the total number of bytes associated with metadata operations. The Minimum statistic is the size of the smallest metadata operation during the period. The Maximum statistic is the size of the largest metadata operation during the period. The Average statistic is the size of the average metadata operation during the period. The SampleCount statistic provides a count of metadata operations.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, SampleCount"
+  },
+  {
+    "metricId": {
+      "metricName": "MetadataWriteIOBytes",
+      "namespace": "AWS/EFS"
+    },
+    "description": "The actual number of bytes for each metadata read operation. The Sum statistic is the total number of bytes associated with metadata read operations. The Minimum statistic is the size of the smallest metadata read operation during the period. The Maximum statistic is the size of the largest metadata read operation during the period. The Average statistic is the average size of metadata read operations during the period. The SampleCount statistic provides a count of metadata read operations.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum, SampleCount"
+  },
+  {
+    "metricId": {
+      "metricName": "DaysToExpiry",
+      "namespace": "AWS/CertificateManager"
+    },
+    "description": "Number of days until a certificate expires. ACM stops publishing this metric after a certificate expires.",
+    "unitInfo": "Integer",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect when a certificate managed by or imported into ACM is approaching its expiration date. It helps to prevent unexpected certificate expirations that could lead to service disruptions. When the alarm transitions into ALARM state, you should take immediate action to renew or re-import the certificate. For ACM-managed certificates, follow the [certificate renewal process](https://docs.aws.amazon.com/acm/latest/userguide/troubleshooting-renewal.html). For imported certificates, follow the [re-import process](https://docs.aws.amazon.com/acm/latest/userguide/import-reimport.html).",
+        "threshold": {
+          "staticValue": 44.0,
+          "justification": "The 44-day threshold provides a balance between early warning and avoiding false alarms. It allows sufficient time for manual intervention if automatic renewal fails. Adjust this value based on your certificate renewal process and operational response times."
+        },
+        "period": 86400,
+        "comparisonOperator": "LessThanOrEqualToThreshold",
+        "statistic": "Minimum",
+        "evaluationPeriods": 1,
+        "datapointsToAlarm": 1,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "CertificateArn"
+          }
+        ],
+        "intent": "This alarm can proactively alert you about upcoming certificate expirations. It provides sufficient advance notice to allow for manual intervention, enabling you to renew or replace certificates before they expire. This helps you maintain the security and availability of TLS-enabled services. When this goes into ALARM, immediately investigate the certificate status and initiate the renewal process if necessary."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "Available",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of WorkSpaces that returned a healthy status.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "Unhealthy",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of WorkSpaces that returned an unhealthy status.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "ConnectionAttempt",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of connection attempts.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "ConnectionSuccess",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of successful connections.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "ConnectionFailure",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of failed connections.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "SessionLaunchTime",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The amount of time it takes to initiate a WorkSpaces session.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "InSessionLatency",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The round trip time between the WorkSpaces client and the WorkSpace.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "SessionDisconnect",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of connections that were closed, including user-initiated and failed connections.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "UserConnected",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of WorkSpaces that have a user connected.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "Stopped",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of WorkSpaces that are stopped.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "Maintenance",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of WorkSpaces that are under maintenance.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "TrustedDeviceValidationAttempt",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of device authentication signature validation attempts.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "TrustedDeviceValidationSuccess",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of successful device authentication signature validations.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "TrustedDeviceValidationFailure",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of failed device authentication signature validations.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "TrustedDeviceCertificateDaysBeforeExpiration",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "Days left before the root certificate associated with the directory is expired.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUUsage",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The percentage of the CPU resource used.",
+    "recommendedStatistics": "Average, Maximum, Minimum"
+  },
+  {
+    "metricId": {
+      "metricName": "MemoryUsage",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The percentage of the machine memory used.",
+    "recommendedStatistics": "Average, Maximum, Minimum"
+  },
+  {
+    "metricId": {
+      "metricName": "RootVolumeDiskUsage",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The percentage of the root disk volume used.",
+    "recommendedStatistics": "Average, Maximum, Minimum"
+  },
+  {
+    "metricId": {
+      "metricName": "UserVolumeDiskUsage",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The percentage of the user disk volume used.",
+    "recommendedStatistics": "Average, Maximum, Minimum"
+  },
+  {
+    "metricId": {
+      "metricName": "UDPPacketLossRate",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The percentage of packets dropped between the client and the gateway.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "UpTime",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The time since the last reboot of a WorkSpace.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "Restoring",
+      "namespace": "AWS/WorkSpaces"
+    },
+    "description": "The number of WorkSpaces that returned a restoring status.",
+    "recommendedStatistics": "Average, Sum, Maximum, Minimum, Data Samples"
+  },
+  {
+    "metricId": {
+      "metricName": "BinLogDiskUsage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of disk space occupied by binary logs. If automatic backups are enabled for MySQL and MariaDB instances, including read replicas, binary logs are created.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "BurstBalance",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The percent of General Purpose SSD (gp2) burst-bucket I/O credits available.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "CheckpointLag",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of time since the most recent checkpoint.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ConnectionAttempts",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of attempts to connect to an instance, whether successful or not.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUUtilization",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The percentage of CPU utilization.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percentage",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor consistent high CPU utilization. CPU utilization measures non-idle time. Consider using [Enhanced Monitoring](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.Enabling.html) or [Performance Insights](https://aws.amazon.com/rds/performance-insights/) to review which [wait time](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring-Available-OS-Metrics.html) is consuming the most of the CPU time (`guest`, `irq`, `wait`, `nice`, etc) for MariaDB, MySQL, Oracle, and PostgreSQL. Then evaluate which queries consume the highest amount of CPU. If you cannot tune your workload, consider moving to a larger DB instance class.",
+        "threshold": {
+          "staticValue": 90.0,
+          "justification": "Random spikes in CPU consumption may not hamper database performance, but sustained high CPU can hinder upcoming database requests. Depending on the overall database workload, high CPU at your RDS/Aurora instance can degrade the overall performance."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to detect consistent high CPU utilization in order to prevent very high response time and time-outs. If you want to check micro-bursting of CPU utilization you can set a lower alarm evaluation time."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "CPUCreditUsage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of CPU credits spent by the instance for CPU utilization. One CPU credit equals one vCPU running at 100 percent utilization for one minute or an equivalent combination of vCPUs, utilization, and time. For example, you might have one vCPU running at 50 percent utilization for two minutes or two vCPUs running at 25 percent utilization for two minutes. CPU credit metrics are available at a five-minute frequency only. If you specify a period greater than five minutes, use the Sum statistic instead of the Average statistic. We recommend using the T DB instance classes only for development and test servers, or other non-production servers. For more details on the T instance classes, see [RDS DB instance class types](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.Types.html) and [Aurora DB instance class types](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.DBInstanceClass.Types.html). For RDS, this metric applies only to `db.t2`, `db.t3`, and `db.t4g` instances. For Aurora database engine, this metric applies only to these instance classes: Aurora MySQL: `db.t2.small`, `db.t2.medium`, `db.t3`, and `db.t4g`. Aurora PostgreSQL: `db.t3` and `db.t4g`.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Credits (vCPU-minutes)"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUCreditBalance",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of earned CPU credits that an instance has accrued since it was launched or started. CPU credit metrics are available at a five-minute frequency only. Launch credits work the same way in Amazon RDS as they do in Amazon EC2. For more information, see [Launch credits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-standard-mode-concepts.html#launch-credits) in the Amazon Elastic Compute Cloud User Guide for Linux Instances. We recommend using the T DB instance classes only for development and test servers, or other non-production servers. For more details on the T instance classes, see [RDS DB instance class types](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.Types.html) and [Aurora DB instance class types](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.DBInstanceClass.Types.html). For RDS, this metric applies only to `db.t2`, `db.t3`, and `db.t4g` instances. For T2 Standard, the `CPUCreditBalance` also includes the number of launch credits that have been accrued. Credits are accrued in the credit balance after they are earned, and removed from the credit balance when they are spent. The credit balance has a maximum limit, determined by the instance size. After the limit is reached, any new credits that are earned are discarded. For T2 Standard, launch credits don't count towards the limit. The credits in the `CPUCreditBalance` are available for the instance to spend to burst beyond its baseline CPU utilization. When an instance is running, credits in the `CPUCreditBalance` don't expire. When the instance stops, the `CPUCreditBalance` does not persist, and all accrued credits are lost. For Aurora database engine, this metric applies only to these instance classes: Aurora MySQL: `db.t2.small`, `db.t2.medium`, `db.t3`, and `db.t4g`. Aurora PostgreSQL: `db.t3` and `db.t4g`.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Credits (vCPU-minutes)"
+  },
+  {
+    "metricId": {
+      "metricName": "DatabaseConnections",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of client network connections to the database instance. The number of database sessions can be higher than the metric value because the metric value doesn't include the following: Sessions that no longer have a network connection but which the database hasn't cleaned up. Sessions created by the database engine for its own purposes. Sessions created by the database engine's parallel execution capabilities. Sessions created by the database engine job scheduler. Amazon RDS/Aurora connections.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects a high number of connections. Review existing connections and terminate any that are in `sleep` state or that are improperly closed. Consider using connection pooling to limit the number of new connections. Alternatively, increase the DB instance size to use a class with more memory and hence a higher default value for `max_connections` or increase the `max_connections` value in [RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html) and Aurora [MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Performance.html) and [PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Managing.html) for the current class if it can support your workload.",
+        "threshold": {
+          "justification": "The number of connections allowed depends on the size of your DB instance class and database engine-specific parameters related to processes/connections. You should calculate a value between 90-95% of the maximum number of connections for your database and use that result as the threshold value."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to help prevent rejected connections when the maximum number of DB connections is reached. This alarm is not recommended if you frequently change DB instance class, because doing so changes the memory and default maximum number of connections."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "DiskQueueDepth",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of outstanding I/Os (read/write requests) waiting to access the disk.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "EBSByteBalance%",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The percentage of throughput credits remaining in the burst bucket of your RDS database. This metric is available for basic monitoring only. The metric value is based on the throughput of all volumes, including the root volume, rather than on only those volumes containing database files. To find the instance sizes that support this metric, see the instance sizes with an asterisk (*) in the [EBS optimized by default](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html#current) table in Amazon EC2 User Guide. The Sum statistic is not applicable to this metric.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percentage",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor a low percentage of throughput credits remaining. For troubleshooting, check [latency problems in RDS](https://repost.aws/knowledge-center/rds-latency-ebs-iops-bottleneck).",
+        "threshold": {
+          "staticValue": 10.0,
+          "justification": "A throughput credit balance below 10% is considered to be poor and you should set the threshold accordingly. You can also set a lower threshold if your application can tolerate a lower throughput for the workload."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to detect a low percentage of throughput credits remaining in the burst bucket. Low byte balance percentage can cause throughput bottleneck issues. This alarm is not recommended for Aurora PostgreSQL instances."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "EBSIOBalance%",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The percentage of I/O credits remaining in the burst bucket of your RDS database. This metric is available for basic monitoring only. The metric value is based on the IOPS of all volumes, including the root volume, rather than on only those volumes containing database files. To find the instance sizes that support this metric, see [Amazon EBS–optimized instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html) in Amazon EC2 User Guide. The Sum statistic isn't applicable to this metric. This metric is different from `BurstBalance`. To learn how to use this metric, see [Improving application performance and reducing costs with Amazon EBS-Optimized Instance burst capability](https://aws.amazon.com/blogs/compute/improving-application-performance-and-reducing-costs-with-amazon-ebs-optimized-instance-burst-capability/).",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percentage",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor low percentage of IOPS credits remaining. For troubleshooting, see [latency problems in RDS](https://repost.aws/knowledge-center/rds-latency-ebs-iops-bottleneck).",
+        "threshold": {
+          "staticValue": 10.0,
+          "justification": "An IOPS credits balance below 10% is considered to be poor and you can set the threshold accordingly. You can also set a lower threshold, if your application can tolerate a lower IOPS for the workload."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to detect a low percentage of I/O credits remaining in the burst bucket. Low IOPS balance percentage can cause IOPS bottleneck issues. This alarm is not recommended for Aurora instances."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "FailedSQLServerAgentJobsCount",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of failed Microsoft SQL Server Agent jobs during the last minute.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count per minute"
+  },
+  {
+    "metricId": {
+      "metricName": "FreeableMemory",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of available random access memory. For MariaDB, MySQL, Oracle, PostgreSQL DB, Aurora MySQL and Aurora PostgreSQL instances, this metric reports the value of the `MemAvailable` field of `/proc/meminfo`.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Bytes",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor low freeable memory which can mean that there is a spike in database connections or that your instance may be under high memory pressure. Check for memory pressure by monitoring the CloudWatch metrics for `SwapUsage` in addition to `FreeableMemory`. If the instance memory consumption is frequently too high, this indicates that you should check your workload or upgrade your instance class. For Aurora reader DB instance, consider adding additional reader DB instances to the cluster. For troubleshooting Aurora, see [freeable memory issues](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/CHAP_Troubleshooting.html#Troubleshooting.FreeableMemory).",
+        "threshold": {
+          "justification": "Depending on the workload and instance class, different values for the threshold can be appropriate. Ideally, available memory should not go below 25% of total memory for prolonged periods. For Aurora, you can set the threshold close to 5%, because the metric approaching 0 means that the DB instance has scaled up as much as it can. You can analyze the historical behavior of this metric to determine sensible threshold levels."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to help prevent running out of memory which can result in rejected connections."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "FreeLocalStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of available local storage space. This metric only applies to DB instance classes with NVMe SSD instance store volumes. For information about Amazon EC2 instances with NVMe SSD instance store volumes, see [Instance store volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes). The equivalent RDS DB instance classes have the same instance store volumes. For example, the db.m6gd and db.r6gd DB instance classes have NVMe SSD instance store volumes. For Aurora DB instances this metric reports the amount of storage available to each DB instance. This value depends on the DB instance class (for pricing information, see the [Amazon RDS pricing page](http://aws.amazon.com/rds/pricing)). You can increase the amount of free storage space for an instance by choosing a larger DB instance class for your instance. (This doesn't apply to Aurora Serverless v2.)",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Bytes",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor low free local storage. Aurora PostgreSQL-Compatible uses local storage for storing error logs and temporary files. Aurora for MySQL uses local storage for storing error logs, general logs, slow query logs, audit logs, and non-InnoDB temporary tables. These local storage volumes are backed by Amazon Elastic Block Store and can be extended by using a larger DB instance class. For troubleshooting, check Aurora [PostgreSQL-Compatible](https://repost.aws/knowledge-center/postgresql-aurora-storage-issue) and [MySQL-Compatible](https://repost.aws/knowledge-center/aurora-mysql-local-storage).",
+        "threshold": {
+          "justification": "You should calculate about 10%-20% of the amount of storage available based on velocity and trend of volume usage, and then use that result as the threshold value to proactively take action before the volume reaches its limit."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to detect how close the Aurora DB instance is to reaching the local storage limit, if you do not use Aurora Serverless v2 or higher. Local storage can reach capacity when you store non-persistent data, such as temporary table and log files, in the local storage. This alarm can prevent an out-of-space error that occurs when your DB instance runs out of local storage."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "FreeStorageSpace",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of available storage space.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Bytes",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm watches for a low amount of available storage space. Consider scaling up your database storage if you frequently approach storage capacity limits. Include some buffer to accommodate unforeseen increases in demand from your applications. Alternatively, consider enabling RDS storage auto scaling. Additionally, consider freeing up more space by deleting unused or outdated data and logs. For further information, check [RDS run out of storage document](https://repost.aws/knowledge-center/rds-out-of-storage) and [PostgreSQL storage issues document](https://repost.aws/knowledge-center/diskfull-error-rds-postgresql).",
+        "threshold": {
+          "justification": "The threshold value will depend on the currently allocated storage space. Typically, you should calculate the value of 10 percent of the allocated storage space and use that result as the threshold value."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Minimum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm helps prevent storage full issues. This can prevent downtime that occurs when your database instance runs out of storage. We do not recommend using this alarm if you have storage auto scaling enabled, or if you frequently change the storage capacity of the database instance."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "MaximumUsedTransactionIDs",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The maximum transaction IDs that have been used. For Aurora database engine, this metric represents the age of the oldest unvacuumed transaction ID, in transactions. If this value reaches 2,146,483,648 (2^31 - 1,000,000), the database is forced into read-only mode, to avoid transaction ID wraparound. For more information, see Preventing transaction ID wraparound failures in the PostgreSQL documentation.",
+    "recommendedStatistics": "Average, Maximum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps prevent transaction ID wraparound for PostgreSQL. Refer to the troubleshooting steps in [this blog](https://aws.amazon.com/blogs/database/implement-an-early-warning-system-for-transaction-id-wraparound-in-amazon-rds-for-postgresql/) to investigate and resolve the issue. You can also refer to [this blog](https://aws.amazon.com/blogs/database/understanding-autovacuum-in-amazon-rds-for-postgresql-environments/) to familiarize yourself further with autovacuum concepts, common issues and best practices.",
+        "threshold": {
+          "staticValue": 1.0E9,
+          "justification": "Setting this threshold to 1 billion should give you time to investigate the problem. The default autovacuum_freeze_max_age value is 200 million. If the age of the oldest transaction is 1 billion, autovacuum is having a problem keeping this threshold below the target of 200 million transaction IDs."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 1,
+        "datapointsToAlarm": 1,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to help prevent transaction ID wraparound for PostgreSQL."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkReceiveThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The incoming (receive) network traffic on the DB instance, including both customer database traffic and Amazon RDS traffic used for monitoring and replication. For Aurora database engine, this metric represents the amount of network throughput received from clients by each instance in the Aurora DB cluster. This throughput doesn't include network traffic between instances in the Aurora DB cluster and the cluster volume.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkTransmitThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The outgoing (transmit) network traffic on the DB instance, including both customer database traffic and Amazon RDS traffic used for monitoring and replication. For Aurora database engine, this metric represents the amount of network throughput sent to clients by each instance in the Aurora DB cluster. This throughput doesn't include network traffic between instances in the DB cluster and the cluster volume.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "OldestReplicationSlotLag",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The lagging size of the replica lagging the most in terms of write-ahead log (WAL) data received.",
+    "recommendedStatistics": "Maximum, Average, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadIOPS",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of disk read I/O operations per second.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average amount of time taken per disk I/O operation.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean, SampleCount",
+    "unitInfo": "Seconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor high read latency. If storage latency is high, it's because the workload is exceeding resource limits. You can review I/O utilization relative to instance and allocated storage configuration. Refer to [troubleshoot the latency of Amazon EBS volumes caused by an IOPS bottleneck](https://repost.aws/knowledge-center/rds-latency-ebs-iops-bottleneck). For Aurora, you can switch to an instance class that has [I/O-Optimized storage configuration](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.Aurora_Fea_Regions_DB-eng.Feature.storage-type.html). See [Planning I/O in Aurora](https://aws.amazon.com/blogs/database/planning-i-o-in-amazon-aurora/) for guidance.",
+        "threshold": {
+          "justification": "The recommended threshold value for this alarm is highly dependent on your use case. Read latencies higher than 20 milliseconds are likely a cause for investigation. You can also set a higher threshold if your application can have higher latency for read operations. Review the criticality and requirements of read latency and analyze the historical behavior of this metric to determine sensible threshold levels."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "p90",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to detect high read latency. Database disks normally have a low read/write latency, but they can have issues that can cause high latency operations."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ReadThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of bytes read from disk per second.",
+    "recommendedStatistics": "Average, Maximum, Sum, Minimum",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "ReplicaLag",
+      "namespace": "AWS/RDS"
+    },
+    "description": "For read replica configurations, the amount of time a read replica DB instance lags behind the source DB instance. Applies to MariaDB, Microsoft SQL Server, MySQL, Oracle, and PostgreSQL read replicas. For Multi-AZ DB clusters, the difference in time between the latest transaction on the writer DB instance and the latest applied transaction on a reader DB instance.",
+    "recommendedStatistics": "Maximum, Average, Minimum",
+    "unitInfo": "Seconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you understand the number of seconds a replica is behind the primary instance. A PostgreSQL Read Replica reports a replication lag of up to five minutes if there are no user transactions occurring on the source database instance. When the ReplicaLag metric reaches 0, the replica has caught up to the primary DB instance. If the ReplicaLag metric returns -1, then replication is currently not active. For guidance related to RDS PostgreSQL, see [replication best practices](https://aws.amazon.com/blogs/database/best-practices-for-amazon-rds-postgresql-replication/) and for troubleshooting `ReplicaLag` and related errors, see [troubleshooting ReplicaLag](https://repost.aws/knowledge-center/rds-postgresql-replication-lag).",
+        "threshold": {
+          "staticValue": 60.0,
+          "justification": "Typically, the acceptable lag depends on the application. We recommend no more than 60 seconds."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm can detect the replica lag which reflects the data loss that could happen in case of a failure of the primary instance. If the replica gets too far behind the primary and the primary fails, the replica will be missing data that was in the primary instance."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ReplicationSlotDiskUsage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The disk space used by replication slot files.",
+    "recommendedStatistics": "Average, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "SwapUsage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of swap space used. For Aurora database engine, this metric isn't available for the following DB instance classes: db.r3.*, db.r4.*, and db.r7g.* (Aurora MySQL). db.r7g.* (Aurora PostgreSQL).",
+    "recommendedStatistics": "Average, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "TransactionLogsDiskUsage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of disk space consumed by transaction logs. For Aurora database engine, this metric is generated only when Aurora PostgreSQL is using logical replication or AWS Database Migration Service. By default, Aurora PostgreSQL uses log records, not transaction logs. When transaction logs aren't in use, the value for this metric is `-1`.",
+    "recommendedStatistics": "Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "TransactionLogsGeneration",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The size of transaction logs generated per second.",
+    "recommendedStatistics": "Maximum, Average",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteIOPS",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of disk write I/O operations per second. For Aurora database engine, this metric represents the number of Aurora storage write records generated per second. This is more or less the number of log records generated by the database. These do not correspond to 8K page writes, and do not correspond to network packets sent.",
+    "recommendedStatistics": "Average, Maximum, Sum, Minimum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average amount of time taken per disk I/O operation.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean, SampleCount",
+    "unitInfo": "Seconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor high write latency. If storage latency is high, it's because the workload is exceeding resource limits. You can review I/O utilization relative to instance and allocated storage configuration. Refer to [troubleshoot the latency of Amazon EBS volumes caused by an IOPS bottleneck](https://repost.aws/knowledge-center/rds-latency-ebs-iops-bottleneck). For Aurora, you can switch to an instance class that has [I/O-Optimized storage configuration](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.Aurora_Fea_Regions_DB-eng.Feature.storage-type.html). See [Planning I/O in Aurora](https://aws.amazon.com/blogs/database/planning-i-o-in-amazon-aurora/) for guidance.",
+        "threshold": {
+          "justification": "The recommended threshold value for this alarm is highly dependent on your use case. Write latencies higher than 20 milliseconds are likely a cause for investigation. You can also set a higher threshold if your application can have a higher latency for write operations. Review the criticality and requirements of write latency and analyze the historical behavior of this metric to determine sensible threshold levels."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "p90",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to detect high write latency. Although database disks typically have low read/write latency, they may experience problems that cause high latency operations. Monitoring this will assure you the disk latency is as low as expected."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "WriteThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of bytes written to disk per second.",
+    "recommendedStatistics": "Average, Maximum, Sum, Minimum",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "DBLoad",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of active sessions for the database. Typically, you want the data for the average number of active sessions. In Performance Insights, this data is queried as `db.load.avg`.",
+    "recommendedStatistics": "Average, Maximum",
+    "unitInfo": "The average active sessions (AAS) is the unit for the DBLoad metrics in Performance Insights. It measures how many sessions are concurrently active on the database.",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor high DB load. If the number of processes exceed the number of vCPUs, the processes start queuing. When the queuing increases, the performance is impacted. If the DB load is often above the maximum vCPU, and the primary wait state is CPU, the CPU is overloaded. In this case, you can monitor `CPUUtilization`, `DBLoadCPU` and  queued tasks in Performance Insights/Enhanced Monitoring. You might want to throttle connections to the instance, tune any SQL queries with a high CPU load, or consider a larger instance class. High and consistent instances of any wait state indicate that there might be bottlenecks or resource contention issues to resolve.",
+        "threshold": {
+          "justification": "The maximum vCPU value is determined by the number of vCPU (virtual CPU) cores for your DB instance. Depending on the maximum vCPU, different values for the threshold can be appropriate. Ideally, DB load should not go above vCPU line."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to detect a high DB load. High DB load can cause performance issues in the DB instance. This alarm is not applicable to serverless DB instances."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "DBLoadCPU",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of active sessions where the wait event type is CPU. In Performance Insights, this data is queried as `db.load.avg`, filtered by the wait event type `CPU`.",
+    "recommendedStatistics": "Average, Maximum",
+    "unitInfo": "The average active sessions (AAS) is the unit for the DBLoad metrics in Performance Insights. It measures how many sessions are concurrently active on the database."
+  },
+  {
+    "metricId": {
+      "metricName": "DBLoadNonCPU",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of active sessions where the wait event type is not CPU.",
+    "recommendedStatistics": "Average, Maximum",
+    "unitInfo": "The average active sessions (AAS) is the unit for the DBLoad metrics in Performance Insights. It measures how many sessions are concurrently active on the database."
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraGlobalDBDataTransferBytes",
+      "namespace": "AWS/RDS"
+    },
+    "description": "In an Aurora Global Database, the amount of redo log data transferred from the source AWS Region to a secondary AWS Region. Note: This metric is available only in secondary AWS Regions.",
+    "recommendedStatistics": "Minimum, Average, Maximum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraGlobalDBProgressLag",
+      "namespace": "AWS/RDS"
+    },
+    "description": "In an Aurora Global Database, the measure of how far the secondary cluster is behind the primary cluster for both user transactions and system transactions. Note: This metric is available only in secondary AWS Regions.",
+    "recommendedStatistics": "Minimum, Average, Maximum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraGlobalDBReplicatedWriteIO",
+      "namespace": "AWS/RDS"
+    },
+    "description": "In an Aurora Global Database, the number of write I/O operations replicated from the primary AWS Region to the cluster volume in a secondary AWS Region. The billing calculations for the secondary AWS Regions in a global database use `VolumeWriteIOPs` to account for writes performed within the cluster. The billing calculations for the primary AWS Region in a global database use `VolumeWriteIOPs` to account for the write activity within that cluster, and `AuroraGlobalDBReplicatedWriteIO` to account for cross-Region replication within the global database. Note: This metric is available only in secondary AWS Regions.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraGlobalDBReplicationLag",
+      "namespace": "AWS/RDS"
+    },
+    "description": "For an Aurora Global Database, the amount of lag when replicating updates from the primary AWS Region. Note: This metric is available only in secondary AWS Regions.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraGlobalDBRPOLag",
+      "namespace": "AWS/RDS"
+    },
+    "description": "In an Aurora Global Database, the recovery point objective (RPO) lag time. This metric measures how far the secondary cluster is behind the primary cluster for user transactions. Note: This metric is available only in secondary AWS Regions.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraVolumeBytesLeftTotal",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The remaining available space for the cluster volume. As the cluster volume grows, this value decreases. If it reaches zero, the cluster reports an out-of-space error. If you want to detect whether your Aurora MySQL cluster is approaching the size limit of 128 tebibytes (TiB), this value is simpler and more reliable to monitor than `VolumeBytesUsed`. `AuroraVolumeBytesLeftTotal` takes into account storage used for internal housekeeping and other allocations that don't affect your storage billing.",
+    "recommendedStatistics": "Minimum, Average, Maximum",
+    "unitInfo": "Bytes",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor low remaining total volume. When the total volume left reaches the size limit, the cluster reports an out-of-space error. Aurora storage automatically scales with the data in the cluster volume and expands up to 128 TiB or 64 TiB depending on the [DB engine version](https://repost.aws/knowledge-center/aurora-version-number). Consider reducing storage by dropping tables and databases that you no longer need. For more information, check [storage scaling](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Managing.Performance.html).",
+        "threshold": {
+          "justification": "You should calculate 10%-20% of the actual size limit based on velocity and trend of volume usage increase, and then use that result as the threshold value to proactively take action before the volume reaches its limit."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "DBClusterIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to detect how close the Aurora cluster is to the volume size limit. This alarm can prevent an out-of-space error that occurs when your cluster runs out of space. This alarm is recommended only for Aurora MySQL."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "BacktrackChangeRecordsCreationRate",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of backtrack change records created over 5 minutes for your DB cluster.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per 5 minutes"
+  },
+  {
+    "metricId": {
+      "metricName": "BacktrackChangeRecordsStored",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of backtrack change records used by your DB cluster.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BackupRetentionPeriodStorageUsed",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The total amount of backup storage used to support the point-in-time restore feature within the Aurora DB cluster's backup retention window. This amount is included in the total reported by the `TotalBackupStorageBilled` metric. It is computed separately for each Aurora cluster. For instructions, see [Understanding Amazon Aurora backup storage usage](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-storage-backup.html).",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ServerlessDatabaseCapacity",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The current capacity of an Aurora Serverless DB cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SnapshotStorageUsed",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The total amount of backup storage consumed by all Aurora snapshots for an Aurora DB cluster outside its backup retention window. This amount is included in the total reported by the `TotalBackupStorageBilled` metric. It is computed separately for each Aurora cluster. For instructions, see [Understanding Amazon Aurora backup storage usage](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-storage-backup.html).",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "TotalBackupStorageBilled",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The total amount of backup storage in bytes for which you are billed for a given Aurora DB cluster. The metric includes the backup storage measured by the `BackupRetentionPeriodStorageUsed` and `SnapshotStorageUsed` metrics. This metric is computed separately for each Aurora cluster. For instructions, see [Understanding Amazon Aurora backup storage usage](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-storage-backup.html).",
+    "recommendedStatistics": "Average, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeBytesUsed",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of storage used by your Aurora DB cluster. This value affects the cost of the Aurora DB cluster (for pricing information, see the [Amazon RDS pricing page](http://aws.amazon.com/rds/pricing)). This value doesn't reflect some internal storage allocations that don't affect storage billing. For Aurora MySQL you can anticipate out-of-space issues more accurately by testing whether `AuroraVolumeBytesLeftTotal` is approaching zero instead of comparing `VolumeBytesUsed` against the storage limit of 128 TiB. For clusters that are clones, the value of this metric depends on the amount of data added or changed on the clone. The metric can also increase or decrease when the original cluster is deleted, or as new clones are added or deleted. For details, see [Deleting a source cluster volume](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Managing.Clone.html#Aurora.Managing.Clone.Deleting). Note that it doesn't make sense to choose a `--period` value that's small, because Amazon RDS collects this metrics at intervals, not continuously.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeReadIOPs",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of billed read I/O operations from a cluster volume within a 5-minute interval. Billed read operations are calculated at the cluster volume level, aggregated from all instances in the Aurora DB cluster, and then reported at 5-minute intervals. The value is calculated by taking the value of the Read operations metric over a 5-minute period. You can determine the amount of billed read operations per second by taking the value of the Billed read operations metric and dividing by 300 seconds. For example, if the Billed read operations returns 13,686, then the billed read operations per second is 45 (13,686 / 300 = 45.62). You accrue billed read operations for queries that request database pages that aren't in the buffer cache and must be loaded from storage. You might see spikes in billed read operations as query results are read from storage and then loaded into the buffer cache. Note that it doesn't make sense to choose a `--period` value that's small, because Amazon RDS collects this metrics at intervals, not continuously. Tip: If your Aurora MySQL cluster uses parallel query, you might see an increase in `VolumeReadIOPS` values. Parallel queries don't use the buffer pool. Thus, although the queries are fast, this optimized processing can result in an increase in read operations and associated charges.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per 5 minutes"
+  },
+  {
+    "metricId": {
+      "metricName": "VolumeWriteIOPs",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of write disk I/O operations to the cluster volume, reported at 5-minute intervals. For a detailed description of how billed write operations are calculated, see `VolumeReadIOPs`. Note that it doesn't make sense to choose a `--period` value that's small, because Amazon RDS collects this metrics at intervals, not continuously.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per 5 minutes"
+  },
+  {
+    "metricId": {
+      "metricName": "AbortedClients",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of client connections that have not been closed properly.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ActiveTransactions",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of current transactions executing on an Aurora database instance per second. By default, Aurora doesn't enable this metric. To begin measuring this value, set `innodb_monitor_enable='all'` in the DB parameter group for a specific DB instance.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "ACUUtilization",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The value of the `ServerlessDatabaseCapacity` metric divided by the maximum ACU value of the DB cluster. This metric is applicable only for Aurora Serverless v2.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percentage"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraBinlogReplicaLag",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of time that a binary log replica DB cluster running on Aurora MySQL lags behind the binary log replication source. A lag means that the source is generating records faster than the replica can apply them. This metric reports different values depending on the engine version: Aurora MySQL version 2 The `Seconds_Behind_Master` field of the MySQL `SHOW SLAVE STATUS`. Aurora MySQL version 3 `SHOW REPLICA STATUS`. You can use this metric to monitor errors and replica lag in a cluster that acts as a binary log replica. The metric value indicates the following: A high value The replica is lagging the replication source. `0` or a value close to `0` The replica process is active and current. `-1` Aurora can't determine the lag, which can happen during replica setup or when the replica is in an error state. Because binary log replication only occurs on the writer instance of the cluster, we recommend using the version of this metric associated with the WRITER role. For more information about administering replication, see [Replicating Amazon Aurora MySQL DB clusters across AWS Regions](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Replication.CrossRegion.html). For more information about troubleshooting, see [Amazon Aurora MySQL replication issues](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/CHAP_Troubleshooting.html#CHAP_Troubleshooting.MySQL).",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Seconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor the error state of Aurora writer instance replication. For more information, see [Replicating Amazon Aurora MySQL DB clusters across AWS Regions](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Replication.CrossRegion.html). For troubleshooting, see [Amazon Aurora MySQL replication issues](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/CHAP_Troubleshooting.html#CHAP_Troubleshooting.MySQL).",
+        "threshold": {
+          "staticValue": -1.0,
+          "justification": "We recommend that you use -1 as the threshold value because Aurora MySQL publishes this value if the replica is in an error state."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanOrEqualToThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 2,
+        "datapointsToAlarm": 2,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "DBClusterIdentifier"
+          },
+          {
+            "name": "Role",
+            "value": "WRITER"
+          }
+        ],
+        "intent": "This alarm is used to detect whether the writer instance is in an error state and can’t replicate the source. This alarm is recommended only for Aurora MySQL."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraReplicaLag",
+      "namespace": "AWS/RDS"
+    },
+    "description": "For an Aurora replica, the amount of lag when replicating updates from the primary instance.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraReplicaLagMaximum",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The maximum amount of lag between the primary instance and any of the Aurora DB instance in the DB cluster. When read replicas are deleted or renamed, there can be a temporary spike in replication lag as the old resource undergoes a recycling process. To obtain an accurate representation of the replication lag during that period, we recommend that you monitor the `AuroraReplicaLag` metric on each read replica instance.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraReplicaLagMinimum",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The minimum amount of lag between the primary instance and any of the Aurora DB instance in the DB cluster.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraSlowConnectionHandleCount",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of connections that have waited two seconds or longer to start the handshake. This metric applies only to Aurora MySQL version 3.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraSlowHandshakeCount",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of connections that have taken 50 milliseconds or longer to finish the handshake. This metric applies only to Aurora MySQL version 3.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BacktrackWindowActual",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The difference between the target backtrack window and the actual backtrack window.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Minutes"
+  },
+  {
+    "metricId": {
+      "metricName": "BacktrackWindowAlert",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of times that the actual backtrack window is smaller than the target backtrack window for a given period of time.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BlockedTransactions",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of transactions in the database that are blocked per second.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count per second",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor a high blocked transaction count in an Aurora DB instance. Blocked transactions can end in either a rollback or a commit. High concurrency, idles in transaction, or long running transactions can lead to blocked transactions. For troubleshooting, see [Aurora MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/ams-waits.row-lock-wait.html) documentation.",
+        "threshold": {
+          "justification": "You should calculate 5% of all transactions of your instance using the ActiveTransactions metric and use that result as the threshold value. You can also review the criticality and requirements of blocked transactions and analyze the historical behavior of this metric to determine sensible threshold levels."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to detect a high count of blocked transactions in an Aurora DB instance in order to prevent transaction rollbacks and performance degradation."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "BufferCacheHitRatio",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The percentage of requests that are served by the buffer cache.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percentage",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you monitor a consistent low cache hit ratio of the Aurora cluster. A low hit ratio indicates that your queries on this DB instance are frequently going to disk. For troubleshooting, investigate your workload to see which queries are causing this behavior, and see the [DB instance RAM recommendations](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.BestPractices.html#Aurora.BestPractices.Performance.Sizing) document.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "You can set the threshold for buffer cache hit ratio to 80%. However, you can adjust this value based on your acceptable performance level and workload characteristics."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to detect consistent low cache hit ratio in order to prevent a sustained performance decrease in the Aurora instance."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "CommitLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average duration taken by the engine and storage to complete the commit operations.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "CommitThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of commit operations per second.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "DDLLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average duration of requests such as example, create, alter, and drop requests.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "DDLThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of DDL requests per second.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "Deadlocks",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of deadlocks in the database per second.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "DeleteLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average duration of delete operations.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "DeleteThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of delete queries per second.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "DMLLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average duration of inserts, updates, and deletes.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "DMLThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of inserts, updates, and deletes per second.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "EngineUptime",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of time that the instance has been running.",
+    "recommendedStatistics": "Minimum, Average, Maximum",
+    "unitInfo": "Seconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor low downtime of the writer DB instance. The writer DB instance can go down due to a reboot, maintenance, upgrade, or failover. When the uptime reaches 0 because of a failover in the cluster, and the cluster has one or more Aurora Replicas, then an Aurora Replica is promoted to the primary writer instance during a failure event. To increase the availability of your DB cluster, consider creating one or more Aurora Replicas in two or more different Availability Zones. For more information check [factors that influence Aurora downtime](https://repost.aws/knowledge-center/aurora-mysql-downtime-factors).",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "A failure event results in a brief interruption, during which read and write operations fail with an exception. However, service is typically restored in less than 60 seconds, and often less than 30 seconds."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanOrEqualToThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 2,
+        "datapointsToAlarm": 2,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "DBClusterIdentifier"
+          },
+          {
+            "name": "Role",
+            "value": "WRITER"
+          }
+        ],
+        "intent": "This alarm is used to detect whether the Aurora writer DB instance is in downtime. This can prevent long-running failure in the writer instance that occurs because of a crash or failover."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "InsertLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average duration of insert operations.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "InsertThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of insert operations per second.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "LoginFailures",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of failed login attempts per second.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of network throughput both received from and transmitted to clients by each instance in the Aurora DB cluster. This throughput doesn't include network traffic between instances in the Aurora DB cluster and the cluster volume.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "NumBinaryLogFiles",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of binlog files generated.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "Queries",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of queries executed per second.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "RDSToAuroraPostgreSQLReplicaLag",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The lag when replicating updates from the primary RDS PostgreSQL instance to other nodes in the cluster.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ResultSetCacheHitRatio",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The percentage of requests that are served by the Resultset cache.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percentage"
+  },
+  {
+    "metricId": {
+      "metricName": "RollbackSegmentHistoryListLength",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The undo logs that record committed transactions with delete-marked records. These records are scheduled to be processed by the InnoDB purge operation.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor a consistent high rollback segment history length of an Aurora instance. A high InnoDB history list length indicates that a large number of old row versions, queries and database shutdowns have become slower. For more information and troubleshooting, see [the InnoDB history list length increased significantly](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/proactive-insights.history-list.html) documentation.",
+        "threshold": {
+          "staticValue": 1000000.0,
+          "justification": "Setting this threshold to 1 million should give you time to investigate the problem. However, you can adjust this value based on your acceptable performance level and workload characteristics."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "DBInstanceIdentifier"
+          }
+        ],
+        "intent": "This alarm is used to detect consistent high rollback segment history length. This can help you prevent sustained performance degradation and high CPU usage in the Aurora instance. This alarm is recommended only for Aurora MySQL."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "RowLockTime",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The total time spent acquiring row locks for InnoDB tables.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "SelectLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average amount of time for select operations.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "SelectThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of select queries per second.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "StorageNetworkReceiveThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of network throughput received from the Aurora storage subsystem by each instance in the DB cluster.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "StorageNetworkThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of network throughput received from and sent to the Aurora storage subsystem by each instance in the Aurora DB cluster.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes per second",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor high storage network throughput. If storage network throughput passes the total network bandwidth of the [EC2 instance](https://aws.amazon.com/ec2/instance-types/), it can lead to high read and write latency, which can cause degraded performance. You can check your EC2 instance type from AWS Console. For troubleshooting, check any changes on write/read latencies and evaluate if you’ve also hit an alarm on this metric. If that is the case, evaluate your workload pattern during the times that the alarm was triggered. This can help you identify if you can optimize your workload to reduce the total amount of network traffic. If this is not possible, you might need to consider scaling your instance.",
+        "threshold": {
+          "justification": "You should calculate about 80%-90% of the total network bandwidth of the EC2 instance type, and then use that result as the threshold value to proactively take action before the network packets are affected. You can also review the criticality and requirements of storage network throughput and analyze the historical behavior of this metric to determine sensible threshold levels."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DBClusterIdentifier"
+          },
+          {
+            "name": "Role",
+            "value": "WRITER"
+          }
+        ],
+        "intent": "This alarm is used to detect high storage network throughput. Detecting high throughput can prevent network packet drops and degraded performance."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "StorageNetworkTransmitThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of network throughput sent to the Aurora storage subsystem by each instance in the Aurora DB cluster.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "SumBinaryLogSize",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The total size of the binlog files.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "TempStorageIOPS",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of IOPS for both read and writes on local storage attached to the DB instance. This metric represents a count and is measured once per second. This metric is applicable only for Aurora Serverless v2.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "TempStorageThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of data transferred to and from local storage associated with the DB instance. This metric represents bytes and is measured once per second. This metric is applicable only for Aurora Serverless v2.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "UpdateLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average amount of time taken for update operations.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "UpdateThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of updates per second.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUSurplusCreditBalance",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of surplus credits that have been spent by an unlimited instance when its `CPUCreditBalance` value is zero. The `CPUSurplusCreditBalance` value is paid down by earned CPU credits. If the number of surplus credits exceeds the maximum number of credits that the instance can earn in a 24-hour period, the spent surplus credits above the maximum incur an additional charge. CPU credit metrics are available at a 5-minute frequency only.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Credits (vCPU-minutes)"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUSurplusCreditsCharged",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of spent surplus credits that are not paid down by earned CPU credits, and which thus incur an additional charge. Spent surplus credits are charged when any of the following occurs: The spent surplus credits exceed the maximum number of credits that the instance can earn in a 24-hour period. Spent surplus credits above the maximum are charged at the end of the hour. The instance is stopped or terminated. The instance is switched from `unlimited` to `standard`. CPU credit metrics are available at a 5-minute frequency only.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Credits (vCPU-minutes)"
+  },
+  {
+    "metricId": {
+      "metricName": "DiskQueueDepthLogVolume",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of outstanding I/Os (read/write requests) waiting to access the log volume disk.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "FreeStorageSpaceLogVolume",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of available storage space on the log volume.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadIOPSLogVolume",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of disk read I/O operations per second for the log volume.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadLatencyLogVolume",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average amount of time taken per disk I/O operation for the log volume.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean, SampleCount",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadThroughputLogVolume",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of bytes read from disk per second for the log volume.",
+    "recommendedStatistics": "Average, Maximum, Sum, Minimum",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteIOPSLogVolume",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of disk write I/O operations per second for the log volume.",
+    "recommendedStatistics": "Average, Maximum, Sum, Minimum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteLatencyLogVolume",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average amount of time taken per disk I/O operation for the log volume.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean, SampleCount",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteThroughputLogVolume",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of bytes written to disk per second for the log volume.",
+    "recommendedStatistics": "Average, Maximum, Sum, Minimum",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraOptimizedReadsCacheHitRatio",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The percentage of requests that are served by the Optimized Reads cache. The value is calculated using the following formula: `orcache_blks_hit/ (orcache_blks_hit + storage_blks_read)`. When `AuroraOptimizedReadsCacheHitRatio` is 100%, it means that all pages were read from the optimized reads cache. If the `AuroraOptimizedReadsCacheHitRatio` is `0`, it means that no pages were read from the optimized reads cache.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percentage"
+  },
+  {
+    "metricId": {
+      "metricName": "FreeEphemeralStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of available Ephemeral NVMe storage.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadIOPSEphemeralStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of disk read I/O operations to Ephemeral NVMe storage.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadLatencyEphemeralStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average amount of time taken per disk read I/O operation for Ephemeral NVMe storage.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean, SampleCount",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadThroughputEphemeralStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of bytes read from disk per second for Ephemeral NVMe storage.",
+    "recommendedStatistics": "Average, Maximum, Sum, Minimum",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteIOPSEphemeralStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of disk write I/O operations to Ephemeral NVMe storage.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteLatencyEphemeralStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average amount of time taken per disk write I/O operation for Ephemeral NVMe storage.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Percentiles, Trimmed Mean, SampleCount",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteThroughputEphemeralStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of bytes written to disk per second for Ephemeral NVMe storage.",
+    "recommendedStatistics": "Average, Maximum, Sum, Minimum",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "ReplicationChannelLag",
+      "namespace": "AWS/RDS"
+    },
+    "description": "For multi-source replica configurations, the amount of time a particular channel on the multi-source replica lags behind the source DB instance. For more information, see [Monitoring multi-source replication channels](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/mysql-multi-source-replication.html#mysql-multi-source-replication-monitoring).",
+    "recommendedStatistics": "Maximum, Average, Minimum",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraEstimatedSharedMemoryBytes",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The estimated amount of shared buffer or buffer pool memory which was actively used during the last configured polling interval.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_bytes_returned",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of bytes for the tuple data structures transmitted to the head node during parallel queries. Divide by 16,384 to compare against `Aurora_pq_pages_pushed_down`."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_max_concurrent_requests",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The maximum number of parallel query sessions that can run concurrently on this Aurora DB instance. This is a fixed number that depends on the AWS DB instance class."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_pages_pushed_down",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of data pages (each with a fixed size of 16 KiB) where parallel query avoided a network transmission to the head node."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_attempted",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query sessions requested. This value might represent more than one session per query, depending on SQL constructs such as subqueries and joins."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_executed",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query sessions run successfully."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_failed",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query sessions that returned an error to the client. In some cases, a request for a parallel query might fail, for example due to a problem in the storage layer. In these cases, the query part that failed is retried using the nonparallel query mechanism. If the retried query also fails, an error is returned to the client and this counter is incremented."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_in_progress",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query sessions currently in progress. This number applies to the particular Aurora DB instance that you are connected to, not the entire Aurora DB cluster. To see if a DB instance is close to its concurrency limit, compare this value to `Aurora_pq_max_concurrent_requests`."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of times parallel query wasn't chosen to satisfy a query. This value is the sum of several other more granular counters. An `EXPLAIN` statement can increment this counter even though the query isn't actually performed."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_below_min_rows",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of times parallel query wasn't chosen due to the number of rows in the table. An `EXPLAIN` statement can increment this counter even though the query isn't actually performed."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_column_bit",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because of an unsupported data type in the list of projected columns."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_column_geometry",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the table has columns with the `GEOMETRY` data type. For information about Aurora MySQL versions that remove this limitation, see [Upgrading parallel query clusters to Aurora MySQL version 3](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-mysql-parallel-query-optimizing.html#aurora-mysql-parallel-query-upgrade-pqv2)."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_column_lob",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the table has columns with a `LOB` data type, or `VARCHAR` columns that are stored externally due to the declared length. For information about Aurora MySQL versions that remove this limitation, see [Upgrading parallel query clusters to Aurora MySQL version 3](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-mysql-parallel-query-optimizing.html#aurora-mysql-parallel-query-upgrade-pqv2)."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_column_virtual",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the table contains a virtual column."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_custom_charset",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the table has columns with a custom character set."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_fast_ddl",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the table is currently being altered by a fast DDL `ALTER` statement."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_few_pages_outside_buffer_pool",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of times parallel query wasn't chosen, even though less than 95 percent of the table data was in the buffer pool, because there wasn't enough unbuffered table data to make parallel query worthwhile."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_full_text_index",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the table has full-text indexes."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_high_buffer_pool_pct",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of times parallel query wasn't chosen because a high percentage of the table data (currently, greater than 95 percent) was already in the buffer pool. In these cases, the optimizer determines that reading the data from the buffer pool is more efficient. An `EXPLAIN` statement can increment this counter even though the query isn't actually performed."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_index_hint",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the query includes an index hint."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_innodb_table_format",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the table uses an unsupported InnoDB row format. Aurora parallel query only applies to the `COMPACT`, `REDUNDANT`, and `DYNAMIC` row formats."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_long_trx",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that used the nonparallel query processing path, due to the query being started inside a long-running transaction. An `EXPLAIN` statement can increment this counter even though the query isn't actually performed."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_no_where_clause",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the query doesn't include any `WHERE` clause."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_range_scan",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the query uses a range scan on an index."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_row_length_too_long",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the total combined length of all the columns is too long."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_small_table",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of times parallel query wasn't chosen due to the overall size of the table, as determined by number of rows and average row length. An `EXPLAIN` statement can increment this counter even though the query isn't actually performed."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_temporary_table",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the query refers to temporary tables that use the unsupported `MyISAM` or `memory` table types."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_tx_isolation",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because query uses an unsupported transaction isolation level. On reader DB instances, parallel query only applies to the `REPEATABLE READ` and `READ COMMITTED` isolation levels."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_update_delete_stmts",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the query is part of an `UPDATE` or `DELETE` statement."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_unsupported_access",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the `WHERE` clause doesn't meet the criteria for parallel query. This result can occur if the query doesn't require a data-intensive scan, or if the query is a `DELETE` or `UPDATE` statement."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_not_chosen_unsupported_storage_type",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of parallel query requests that use the nonparallel query processing path because the Aurora MySQL DB cluster isn't using a supported Aurora cluster storage configuration. This parameter is available in Aurora MySQL version 3.04 and higher. For more information, see [Limitations](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-mysql-parallel-query.html#aurora-mysql-parallel-query-limitations)."
+  },
+  {
+    "metricId": {
+      "metricName": "Aurora_pq_request_throttled",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of times parallel query wasn't chosen due to the maximum number of concurrent parallel queries already running on a particular Aurora DB instance."
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraForwardingWriterDMLThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Number of forwarded DML statements processed each second by this writer DB instance.",
+    "unitInfo": "Count (per second)"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraForwardingWriterOpenSessions",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Number of open sessions on this writer DB instance processing forwarded queries.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraForwardingWriterTotalSessions",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Total number of forwarded sessions on this writer DB instance.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraForwardingReplicaCommitThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Number of commits in sessions forwarded by this replica each second.",
+    "unitInfo": "Count (per second)"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraForwardingReplicaDMLLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Average response time in milliseconds of forwarded DMLs on replica.",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraForwardingReplicaDMLThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Number of forwarded DML statements processed on this replica each second.",
+    "unitInfo": "Count (per second)"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraForwardingReplicaErrorSessionsLimit",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Number of sessions rejected by the primary cluster because the limit for max connections or max write forward connections was reached.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraForwardingReplicaOpenSessions",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of sessions that are using write forwarding on a replica instance.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraForwardingReplicaReadWaitLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Average wait time in milliseconds that the replica waits to be consistent with the LSN of the primary cluster. The degree to which the reader DB instance waits depends on the `apg_write_forward.consistency_mode` setting. For information about this setting, see [Configuration parameters for write forwarding in Aurora PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database-write-forwarding-apg.html#aurora-global-database-write-forwarding-params-apg).",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadIOPSLocalStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of disk read I/O operations to local storage per second. This metric only applies to DB instance classes with NVMe SSD instance store volumes. For information about Amazon EC2 instances with NVMe SSD instance store volumes, see [Instance store volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes). The equivalent RDS DB instance classes have the same instance store volumes. For example, the db.m6gd and db.r6gd DB instance classes have NVMe SSD instance store volumes.",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadLatencyLocalStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average amount of time taken per disk I/O operation for local storage. This metric only applies to DB instance classes with NVMe SSD instance store volumes. For information about Amazon EC2 instances with NVMe SSD instance store volumes, see [Instance store volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes). The equivalent RDS DB instance classes have the same instance store volumes. For example, the db.m6gd and db.r6gd DB instance classes have NVMe SSD instance store volumes.",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadThroughputLocalStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of bytes read from disk per second for local storage. This metric only applies to DB instance classes with NVMe SSD instance store volumes. For information about Amazon EC2 instances with NVMe SSD instance store volumes, see [Instance store volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes). The equivalent RDS DB instance classes have the same instance store volumes. For example, the db.m6gd and db.r6gd DB instance classes have NVMe SSD instance store volumes.",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteIOPSLocalStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of disk write I/O operations per second on local storage. This metric only applies to DB instance classes with NVMe SSD instance store volumes. For information about Amazon EC2 instances with NVMe SSD instance store volumes, see [Instance store volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes). The equivalent RDS DB instance classes have the same instance store volumes. For example, the db.m6gd and db.r6gd DB instance classes have NVMe SSD instance store volumes.",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteLatencyLocalStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average amount of time taken per disk I/O operation on local storage. This metric only applies to DB instance classes with NVMe SSD instance store volumes. For information about Amazon EC2 instances with NVMe SSD instance store volumes, see [Instance store volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes). The equivalent RDS DB instance classes have the same instance store volumes. For example, the db.m6gd and db.r6gd DB instance classes have NVMe SSD instance store volumes.",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "WriteThroughputLocalStorage",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The average number of bytes written to disk per second for local storage. This metric only applies to DB instance classes with NVMe SSD instance store volumes. For information about Amazon EC2 instances with NVMe SSD instance store volumes, see [Instance store volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes). The equivalent RDS DB instance classes have the same instance store volumes. For example, the db.m6gd and db.r6gd DB instance classes have NVMe SSD instance store volumes.",
+    "unitInfo": "Bytes per second"
+  },
+  {
+    "metricId": {
+      "metricName": "PurgeBoundary",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Transaction number up to which InnoDB purging is allowed. If this metric doesn't advance for extended periods of time, it's a good indication that InnoDB purging is blocked by long-running transactions. To investigate, check the active transactions on your Aurora MySQL DB cluster.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PurgeFinishedPoint",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Transaction number up to which InnoDB purging is performed. This metric can help you examine how fast InnoDB purging is progressing.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "TruncateFinishedPoint",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The transaction identifier up to which undo truncation is performed.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingMasterDMLLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Average time to process each forwarded DML statement on the writer DB instance. It doesn't include the time for the secondary cluster to forward the write request, or the time to replicate changes back to the secondary cluster. For Aurora MySQL version 2.",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingMasterDMLThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Number of forwarded DML statements processed each second by this writer DB instance. For Aurora MySQL version 2.",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingMasterOpenSessions",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Number of forwarded sessions on the writer DB instance. For Aurora MySQL version 2.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingWriterDMLLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Average time to process each forwarded DML statement on the writer DB instance. It doesn't include the time for the secondary cluster to forward the write request, or the time to replicate changes back to the secondary cluster. For Aurora MySQL version 3.",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingWriterDMLThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Number of forwarded DML statements processed each second by this writer DB instance. For Aurora MySQL version 3.",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingWriterOpenSessions",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Number of forwarded sessions on the writer DB instance. For Aurora MySQL version 3.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingReplicaDMLLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Average response time of forwarded DMLs on the replica.",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingReplicaDMLThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Number of forwarded DML statements processed each second.",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingReplicaOpenSessions",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Number of sessions that are using write forwarding on a reader DB instance.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingReplicaReadWaitLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Average wait time that a `SELECT` statement on a reader DB instance waits to catch up to the primary cluster. The degree to which the reader DB instance waits before processing a query depends on the `aurora_replica_read_consistency` setting.",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingReplicaReadWaitThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Total number of `SELECT` statements processed each second in all sessions that are forwarding writes.",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingReplicaSelectLatency",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Forwarded `SELECT` latency, average over all forwarded `SELECT` statements within the monitoring period.",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ForwardingReplicaSelectThroughput",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Forwarded `SELECT` throughput per second average within the monitoring period.",
+    "unitInfo": "Count per second"
+  },
+  {
+    "metricId": {
+      "metricName": "FreeLocalStoragePercent",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The percentage of available local storage space. This metric only applies to DB instance classes with NVMe SSD instance store volumes. For information about Amazon EC2 instances with NVMe SSD instance store volumes, see [Instance store volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes). The equivalent RDS DB instance classes have the same instance store volumes. For example, the db.m6gd and db.r6gd DB instance classes have NVMe SSD instance store volumes.",
+    "unitInfo": "Percentage"
+  },
+  {
+    "metricId": {
+      "metricName": "DBLoadRelativeToNumVCPUs",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The ratio of the DB load to the number of virtual CPUs for the database."
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraDMLRejectedMasterFull",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of forwarded queries that are rejected because the session is full on the writer DB instance.For Aurora MySQL version 2.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraDMLRejectedWriterFull",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of forwarded queries that are rejected because the session is full on the writer DB instance.For Aurora MySQL version 3.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraMemoryHealthState",
+      "namespace": "AWS/RDS"
+    },
+    "description": "Indicates the memory health state. A value of `0` equals `NORMAL`. A value of `10` equals `RESERVED`, which means that the server is approaching a critical level of memory usage. For more information, see [Troubleshooting out-of-memory issues for Aurora MySQL databases](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQLOOM.html).",
+    "unitInfo": "Gauge"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraMemoryNumDeclinedSqlTotal",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The incremental number of queries declined as part of out-of-memory (OOM) avoidance. For more information, see [Troubleshooting out-of-memory issues for Aurora MySQL databases](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQLOOM.html).",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraMemoryNumKillConnTotal",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The incremental number of connections closed as part of OOM avoidance. For more information, see [Troubleshooting out-of-memory issues for Aurora MySQL databases](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQLOOM.html).",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraMemoryNumKillQueryTotal",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The incremental number of queries ended as part of OOM avoidance. For more information, see [Troubleshooting out-of-memory issues for Aurora MySQL databases](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQLOOM.html).",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraMillisecondsSpentInOomRecovery",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The amount of time since the memory health dropped below the normal state. For more information, see [Troubleshooting out-of-memory issues for Aurora MySQL databases](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQLOOM.html).",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraNumOomRecoverySuccessful",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of times that the memory health was restored to the normal state. For more information, see [Troubleshooting out-of-memory issues for Aurora MySQL databases](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQLOOM.html).",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AuroraNumOomRecoveryTriggered",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of times that the memory health dropped below the normal state. For more information, see [Troubleshooting out-of-memory issues for Aurora MySQL databases](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQLOOM.html).",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "TransactionAgeMaximum",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The age of the oldest active running transaction.",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "IamDbAuthConnectionRequests",
+      "namespace": "AWS/RDS"
+    },
+    "description": "The number of connection requests using IAM authentication to the DB instance.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_time_active",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that the CPU is active in any capacity. This metric is measured in hundredths of a second.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_time_guest",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that the CPU is running a virtual CPU for a guest operating system. This metric is measured in hundredths of a second.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_time_guest_nice",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that the CPU is running a virtual CPU for a guest operating system, which is low-priority and can be interrupted by other processes. This metric is measured in hundredths of a second.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_time_idle",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that the CPU is idle. This metric is measured in hundredths of a second.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_time_iowait",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that the CPU is waiting for I/O operations to complete. This metric is measured in hundredths of a second.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_time_irq",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that the CPU is servicing interrupts. This metric is measured in hundredths of a second.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_time_nice",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that the CPU is in user mode with low-priority processes, which can easily be interrupted by higher-priority processes. This metric is measured in hundredths of a second.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_time_softirq",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that the CPU is servicing software interrupts. This metric is measured in hundredths of a second.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_time_steal",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that the CPU is in stolen time, which is time spent in other operating systems in a virtualized environment. This metric is measured in hundredths of a second.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_time_system",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that the CPU is in system mode. This metric is measured in hundredths of a second.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_time_user",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that the CPU is in user mode. This metric is measured in hundredths of a second.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_usage_active",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of time that the CPU is active in any capacity.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_usage_guest",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of time that the CPU is running a virtual CPU for a guest operating system.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_usage_guest_nice",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of time that the CPU is running a virtual CPU for a guest operating system, which is low-priority and can be interrupted by other processes.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_usage_idle",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of time that the CPU is idle.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_usage_iowait",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of time that the CPU is waiting for I/O operations to complete.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_usage_irq",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of time that the CPU is servicing interrupts.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_usage_nice",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of time that the CPU is in user mode with low-priority processes, which higher-priority processes can easily interrupt.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_usage_softirq",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of time that the CPU is servicing software interrupts.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_usage_steal",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of time that the CPU is in stolen time, or time spent in other operating systems in a virtualized environment.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_usage_system",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of time that the CPU is in system mode.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "cpu_usage_user",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of time that the CPU is in user mode.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "disk_free",
+      "namespace": "CWAgent"
+    },
+    "description": "Free space on the disks.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "disk_inodes_free",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of available index nodes on the disk.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "disk_inodes_total",
+      "namespace": "CWAgent"
+    },
+    "description": "The total number of index nodes reserved on the disk.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "disk_inodes_used",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of used index nodes on the disk.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "disk_total",
+      "namespace": "CWAgent"
+    },
+    "description": "Total space on the disks, including used and free.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "disk_used",
+      "namespace": "CWAgent"
+    },
+    "description": "Used space on the disks.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "disk_used_percent",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of total disk space that is used.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "diskio_iops_in_progress",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of I/O requests that have been issued to the device driver but have not yet completed.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "diskio_io_time",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that the disk has had I/O requests queued. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "diskio_reads",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of disk read operations. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "diskio_read_bytes",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of bytes read from the disks. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "diskio_read_time",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that read requests have waited on the disks. Multiple read requests waiting at the same time increase the number. For example, if 5 requests all wait for an average of 100 milliseconds, 500 is reported. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "diskio_writes",
+      "namespace": "CWAgent"
+    },
+    "description": "The number disk write operations. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "diskio_write_bytes",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of bytes written to the disks. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "diskio_write_time",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of time that write requests have waited on the disks. Multiple write requests waiting at the same time increase the number. For example, if 8 requests all wait for an average of 1000 milliseconds, 8000 is reported. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ethtool_bw_in_allowance_exceeded",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of packets queued and/or dropped because the inbound aggregate bandwidth exceeded the maximum for the instance. This metric is collected only if you have listed it in the `ethtool` subsection of the `metrics_collected` section of the CloudWatch agent configuration file. For more information, see [Collect network performance metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-network-performance.html).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "ethtool_bw_out_allowance_exceeded",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of packets queued and/or dropped because the outbound aggregate bandwidth exceeded the maximum for the instance. This metric is collected only if you have listed it in the `ethtool` subsection of the `metrics_collected` section of the CloudWatch agent configuration file. For more information, see [Collect network performance metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-network-performance.html).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "ethtool_conntrack_allowance_exceeded",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of packets dropped because connection tracking exceeded the maximum for the instance and new connections could not be established. This can result in packet loss for traffic to or from the instance. This metric is collected only if you have listed it in the `ethtool` subsection of the `metrics_collected` section of the CloudWatch agent configuration file. For more information, see [Collect network performance metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-network-performance.html).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "ethtool_linklocal_allowance_exceeded",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of packets dropped because the PPS of the traffic to local proxy services exceeded the maximum for the network interface. This impacts traffic to the DNS service, the Instance Metadata Service, and the Amazon Time Sync Service. This metric is collected only if you have listed it in the `ethtool` subsection of the `metrics_collected` section of the CloudWatch agent configuration file. For more information, see [Collect network performance metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-network-performance.html).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "ethtool_pps_allowance_exceeded",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of packets queued and/or dropped because the bidirectional PPS exceeded the maximum for the instance. This metric is collected only if you have listed it in the `ethtool` subsection of the `metrics_collected` section of the CloudWatch agent configuration file. For more information, see [Collect network performance metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-network-performance.html).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "mem_active",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of memory that has been used in some way during the last sample period.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "mem_available",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of memory that is available and can be given instantly to processes.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "mem_available_percent",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of memory that is available and can be given instantly to processes.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "mem_buffered",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of memory that is being used for buffers.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "mem_cached",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of memory that is being used for file caches.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "mem_free",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of memory that isn't being used.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "mem_inactive",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of memory that hasn't been used in some way during the last sample period.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "mem_total",
+      "namespace": "CWAgent"
+    },
+    "description": "The total amount of memory.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "mem_used",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of memory currently in use.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "mem_used_percent",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of memory currently in use.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "net_bytes_recv",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of bytes received by the network interface. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "net_bytes_sent",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of bytes sent by the network interface. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "net_drop_in",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of packets received by this network interface that were dropped. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "net_drop_out",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of packets transmitted by this network interface that were dropped. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "net_err_in",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of receive errors detected by this network interface. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "net_err_out",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of transmit errors detected by this network interface. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "net_packets_sent",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of packets sent by this network interface. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "net_packets_recv",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of packets received by this network interface. The only statistic that should be used for this metric is Sum. Do not use Average.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_tcp_close",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of TCP connections with no state.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_tcp_close_wait",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of TCP connections waiting for a termination request from the client.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_tcp_closing",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of TCP connections that are waiting for a termination request with acknowledgement from the client.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_tcp_established",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of TCP connections established.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_tcp_fin_wait1",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of TCP connections in the `FIN_WAIT1` state during the process of closing a connection.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_tcp_fin_wait2",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of TCP connections in the `FIN_WAIT2` state during the process of closing a connection.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_tcp_last_ack",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of TCP connections waiting for the client to send acknowledgement of the connection termination message. This is the last state right before the connection is closed down.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_tcp_listen",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of TCP ports currently listening for a connection request.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_tcp_none",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of TCP connections with inactive clients.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_tcp_syn_sent",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of TCP connections waiting for a matching connection request after having sent a connection request.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_tcp_syn_recv",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of TCP connections waiting for connection request acknowledgement after having sent and received a connection request.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_tcp_time_wait",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of TCP connections currently waiting to ensure that the client received the acknowledgement of its connection termination request.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "netstat_udp_socket",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of current UDP connections.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "processes_blocked",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of processes that are blocked.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "processes_dead",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of processes that are dead, indicated by the `X` state code on Linux. This metric is not collected on macOS computers.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "processes_idle",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of processes that are idle (sleeping for more than 20 seconds). Available only on FreeBSD instances.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "processes_paging",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of processes that are paging, indicated by the `W` state code on Linux. This metric is not collected on macOS computers.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "processes_running",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of processes that are running, indicated by the `R` state code.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "processes_sleeping",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of processes that are sleeping, indicated by the `S` state code.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "processes_stopped",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of processes that are stopped, indicated by the `T` state code.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "processes_total",
+      "namespace": "CWAgent"
+    },
+    "description": "The total number of processes on the instance.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "processes_total_threads",
+      "namespace": "CWAgent"
+    },
+    "description": "The total number of threads making up the processes. This metric is available only on Linux instances. This metric is not collected on macOS computers.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "processes_wait",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of processes that are paging, indicated by the `W` state code on FreeBSD instances. This metric is available only on FreeBSD instances, and is not available on Linux, Windows Server, or macOS instances.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "processes_zombies",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of zombie processes, indicated by the `Z` state code.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "swap_free",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of swap space that isn't being used.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "swap_used",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of swap space currently in use.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "swap_used_percent",
+      "namespace": "CWAgent"
+    },
+    "description": "The percentage of swap space currently in use.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "tomcat.sessions",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of active sessions.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "tomcat.errors",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of errors encountered.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "tomcat.processing_time",
+      "namespace": "CWAgent"
+    },
+    "description": "The total processing time.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "tomcat.traffic",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of bytes transmitted and received.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "tomcat.threads",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of threads.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "tomcat.max_time",
+      "namespace": "CWAgent"
+    },
+    "description": "Maximum time to process a request.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "tomcat.request_count",
+      "namespace": "CWAgent"
+    },
+    "description": "The total requests.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.message.count",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of messages received by the broker.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.request.count",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of requests received by the broker.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.request.failed",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of requests to the broker resulting in a failure.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.request.time.total",
+      "namespace": "CWAgent"
+    },
+    "description": "The total time the broker has taken to service requests.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.request.time.50p",
+      "namespace": "CWAgent"
+    },
+    "description": "The 50th percentile time the broker has taken to service requests.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.request.time.99p",
+      "namespace": "CWAgent"
+    },
+    "description": "The 99th percentile time the broker has taken to service requests.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.request.time.avg",
+      "namespace": "CWAgent"
+    },
+    "description": "The average time the broker has taken to service requests.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.network.io",
+      "namespace": "CWAgent"
+    },
+    "description": "The bytes received or sent by the broker.",
+    "recommendedStatistics": "Minimum, Maximum, Average, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.purgatory.size",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of requests waiting in purgatory.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.partition.count",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of partitions on the broker.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.partition.offline",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of partitions offline.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.partition.under_replicated",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of under replicated partitions.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.isr.operation.count",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of in-sync replica shrink and expand operations.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.max.lag",
+      "namespace": "CWAgent"
+    },
+    "description": "Max lag in messages between follower and leader replicas.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.controller.active.count",
+      "namespace": "CWAgent"
+    },
+    "description": "Controller is active on broker.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.leader.election.rate",
+      "namespace": "CWAgent"
+    },
+    "description": "Leader election rate - increasing indicates broker failures.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.unclean.election.rate",
+      "namespace": "CWAgent"
+    },
+    "description": "Unclean leader election rate - increasing indicates broker failures.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.request.queue",
+      "namespace": "CWAgent"
+    },
+    "description": "Size of the request queue.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.consumer.fetch-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of fetch requests for all topics per second.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.consumer.records-lag-max",
+      "namespace": "CWAgent"
+    },
+    "description": "Number of messages the consumer lags behind the producer.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.consumer.total.bytes-consumed-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "The average number of bytes consumed for all topics per second.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.consumer.total.fetch-size-avg",
+      "namespace": "CWAgent"
+    },
+    "description": "The average number of bytes fetched per request for all topics.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.consumer.total.records-consumed-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "The average number of records consumed for all topics per second.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.consumer.bytes-consumed-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "The average number of bytes consumed per second.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.consumer.fetch-size-avg",
+      "namespace": "CWAgent"
+    },
+    "description": "The average number of bytes fetched per request.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.consumer.records-consumed-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "The average number of records consumed per second.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.producer.io-wait-time-ns-avg",
+      "namespace": "CWAgent"
+    },
+    "description": "The average length of time the I/O thread spent waiting for a socket ready for reads or writes.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Nanoseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.producer.outgoing-byte-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "The average number of outgoing bytes sent per second to all servers.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.producer.request-latency-avg",
+      "namespace": "CWAgent"
+    },
+    "description": "The average request latency.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.producer.request-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "The average number of requests sent per second.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.producer.response-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "Responses received per second.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.producer.byte-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "The average number of bytes sent per second for a topic.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.producer.compression-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "The average compression rate of record batches for a topic.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.producer.record-error-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "The average per-second number of record sends that resulted in errors for a topic.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.producer.record-retry-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "The average per-second number of retried record sends for a topic.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "kafka.producer.record-send-rate",
+      "namespace": "CWAgent"
+    },
+    "description": "The average number of records sent per second for a topic.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.classes.loaded",
+      "namespace": "CWAgent"
+    },
+    "description": "The number of loaded classes.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.gc.collections.count",
+      "namespace": "CWAgent"
+    },
+    "description": "The total number of garbage collections that have occurred.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.gc.collections.elapsed",
+      "namespace": "CWAgent"
+    },
+    "description": "The approximate accumulated collection elapsed time.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.memory.heap.init",
+      "namespace": "CWAgent"
+    },
+    "description": "The initial amount of memory that the JVM requests from the operating system for the heap.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.memory.heap.max",
+      "namespace": "CWAgent"
+    },
+    "description": "The maximum amount of memory can be used for the heap.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.memory.heap.used",
+      "namespace": "CWAgent"
+    },
+    "description": "The current heap memory usage.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.memory.heap.committed",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of memory that is guaranteed to be available for the heap.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.memory.nonheap.init",
+      "namespace": "CWAgent"
+    },
+    "description": "The initial amount of memory that the JVM requests from the operating system for non-heap purposes.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.memory.nonheap.max",
+      "namespace": "CWAgent"
+    },
+    "description": "The maximum amount of memory can be used for non-heap purposes.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.memory.nonheap.used",
+      "namespace": "CWAgent"
+    },
+    "description": "The current non-heap memory usage.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.memory.nonheap.committed",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of memory that is guaranteed to be available for non-heap purposes.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.memory.pool.init",
+      "namespace": "CWAgent"
+    },
+    "description": "The initial amount of memory that the JVM requests from the operating system for the memory pool.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.memory.pool.max",
+      "namespace": "CWAgent"
+    },
+    "description": "The maximum amount of memory can be used for the memory pool.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.memory.pool.used",
+      "namespace": "CWAgent"
+    },
+    "description": "The current memory pool memory usage.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.memory.pool.committed",
+      "namespace": "CWAgent"
+    },
+    "description": "The amount of memory that is guaranteed to be available for the memory pool.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "jvm.threads.count",
+      "namespace": "CWAgent"
+    },
+    "description": "The current number of threads.",
+    "recommendedStatistics": "Minimum, Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BucketSizeBytes",
+      "namespace": "AWS/S3"
+    },
+    "description": "The amount of data in bytes that is stored in a bucket in the following storage classes: Reduced Redundancy Storage (RRS) (`REDUCED_REDUNDANCY`). S3 Express One Zone (`EXPRESS_ONEZONE`). S3 Glacier Deep Archive (`DEEP_ARCHIVE`). S3 Glacier Flexible Retrieval (`GLACIER`). S3 Glacier Instant Retrieval (`GLACIER_IR`). S3 Intelligent-Tiering (`INTELLIGENT_TIERING`). S3 One Zone-Infrequent Access (`ONEZONE_IA`). S3 Standard (`STANDARD`). S3 Standard-Infrequent Access (`STANDARD_IA`). This value is calculated by summing the size of all objects and metadata (such as bucket names) in the bucket (both current and noncurrent objects), including the size of all parts for all incomplete multipart uploads to the bucket. Valid storage-type filters: Reduced Redundancy Storage (RRS): `ReducedRedundancyStorage`. S3 Express One Zone: `ExpressOneZoneStorage`. S3 Glacier Deep Archive: `DeepArchiveObjectOverhead`, `DeepArchiveS3ObjectOverhead`, `DeepArchiveStagingStorage`, `DeepArchiveStorage`. S3 Glacier Flexible Retrieval: `GlacierObjectOverhead`, `GlacierS3ObjectOverhead`, `GlacierStagingStorage`, `GlacierStorage`. S3 Glacier Instant Retrieval: `GlacierInstantRetrievalStorage`, `GlacierIRSizeOverhead`. S3 Intelligent-Tiering: `IntelligentTieringAAStorage`, `IntelligentTieringAIAStorage`, `IntelligentTieringDAAStorage`, `IntelligentTieringFAStorage`, `IntelligentTieringIAStorage`. S3 One Zone-Infrequent Access: `OneZoneIASizeOverhead`, `OneZoneIAStorage`. S3 Standard: `StandardStorage`. S3 Standard-Infrequent Access: `StandardIAObjectOverhead`, `StandardIASizeOverhead`, `StandardIAStorage`. For more information about the `StorageType` dimensions, see [Amazon S3 dimensions in CloudWatch](https://docs.aws.amazon.com/AmazonS3/latest/userguide/metrics-dimensions.html#s3-cloudwatch-dimensions). Note: The S3 Express One Zone storage class is available only for directory buckets.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfObjects",
+      "namespace": "AWS/S3"
+    },
+    "description": "The total number of objects stored in a general purpose bucket for all storage classes. This value is calculated by counting all objects in the bucket, which includes current and noncurrent objects, delete markers, and the total number of parts for all incomplete multipart uploads to the bucket. For directory buckets with objects in the S3 Express One Zone storage class, this value is calculated by counting all objects in the bucket, but it doesn't include incomplete multiple uploads to the bucket. Valid storage type filters: `AllStorageTypes`.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "AllRequests",
+      "namespace": "AWS/S3"
+    },
+    "description": "The total number of HTTP requests made to an Amazon S3 bucket, regardless of type. If you're using a metrics configuration with a filter, then this metric returns only the HTTP requests that meet the filter's requirements.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "GetRequests",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of HTTP `GET` requests made for objects in an Amazon S3 bucket. This doesn't include list operations. This metric is incremented for the source of each `CopyObject` request. Note: Paginated list-oriented requests, such as [ListMultipartUploads](https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html), [ListParts](https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListParts.html), [ListObjectVersions](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETVersion.html), and others, are not included in this metric.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PutRequests",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of HTTP `PUT` requests made for objects in an Amazon S3 bucket. This metric is incremented for the destination of each `CopyObject` request.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DeleteRequests",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of HTTP `DELETE` requests made for objects in an Amazon S3 bucket. This metric also includes [DeleteObjects](https://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html) requests. This metric shows the number of requests made, not the number of objects deleted.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "HeadRequests",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of HTTP `HEAD` requests made to an Amazon S3 bucket.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PostRequests",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of HTTP `POST` requests made to an Amazon S3 bucket. Note: [DeleteObjects](https://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html) and [SelectObjectContent](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html) requests are not included in this metric.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SelectRequests",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of Amazon S3 [SelectObjectContent](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html) requests made for objects in an Amazon S3 bucket.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "SelectBytesScanned",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of bytes of data scanned with Amazon S3 [SelectObjectContent](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html) requests in an Amazon S3 bucket.",
+    "recommendedStatistics": "Average (bytes per request), Sum (bytes per period), Sample Count, Min, Max (same as p100), any percentile between p0.0 and p99.9",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "SelectBytesReturned",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of bytes of data returned with Amazon S3 [SelectObjectContent](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html) requests in an Amazon S3 bucket.",
+    "recommendedStatistics": "Average (bytes per request), Sum (bytes per period), Sample Count, Min, Max (same as p100), any percentile between p0.0 and p99.9",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ListRequests",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of HTTP requests that list the contents of a bucket.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesDownloaded",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of bytes downloaded for requests made to an Amazon S3 bucket, where the response includes a body.",
+    "recommendedStatistics": "Average (bytes per request), Sum (bytes per period), Sample Count, Min, Max (same as p100), any percentile between p0.0 and p99.9",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesUploaded",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of bytes uploaded for requests made to an Amazon S3 bucket, where the request includes a body.",
+    "recommendedStatistics": "Average (bytes per request), Sum (bytes per period), Sample Count, Min, Max (same as p100), any percentile between p0.0 and p99.9",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "4xxErrors",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of HTTP 4xx client error status code requests made to an Amazon S3 bucket with a value of either 0 or 1. The Average statistic shows the error rate, and the Sum statistic shows the count of that type of error, during each period.",
+    "recommendedStatistics": "Average (reports per request), Sum (reports per period), Min, Max, Sample Count",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps us report the total number of 4xx error status codes that are made in response to client requests. 403 error codes might indicate an incorrect IAM policy, and 404 error codes might indicate mis-behaving client application, for example. [Enabling S3 server access logging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html) on a temporary basis will help you to pinpoint the issue's origin using the fields HTTP status and Error Code. To understand more about the error code, see [Error Responses](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html).",
+        "threshold": {
+          "staticValue": 0.05,
+          "justification": "The recommended threshold is to detect if more than 5% of total requests are getting 4XX errors. Frequently occurring 4XX errors should be alarmed. However, setting a very low value for the threshold can cause alarm to be too sensitive. You can also tune the threshold to suit to the load of the requests, accounting for an acceptable level of 4XX errors. You can also analyze historical data to find the acceptable error rate for the application workload, and then tune the threshold accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "BucketName"
+          },
+          {
+            "name": "FilterId"
+          }
+        ],
+        "intent": "This alarm is used to create a baseline for typical 4xx error rates so that you can look into any abnormalities that might indicate a setup issue."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "5xxErrors",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of HTTP 5xx server error status code requests made to an Amazon S3 bucket with a value of either 0 or 1. The Average statistic shows the error rate, and the Sum statistic shows the count of that type of error, during each period.",
+    "recommendedStatistics": "Average (reports per request), Sum (reports per period), Min, Max, Sample Count",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect a high number of server-side errors. These errors indicate that a client made a request that the server couldn’t complete. This can help you correlate the issue your application is facing because of S3. For more information to help you efficiently handle or reduce errors, see [Optimizing performance design patterns](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance-design-patterns.html#optimizing-performance-timeouts-retries). Errors might also be caused by an the issue with S3, check [AWS service health dashboard](https://health.aws.amazon.com/health/status) for the status of AWS S3 in your Region.",
+        "threshold": {
+          "staticValue": 0.05,
+          "justification": "We recommend setting the threshold to detect if more than 5% of total requests are getting 5XXError. However, you can tune the threshold to suit the traffic of the requests, as well as acceptable error rates. You can also analyze historical data to see what is the acceptable error rate for the application workload, and tune the threshold accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "BucketName"
+          },
+          {
+            "name": "FilterId"
+          }
+        ],
+        "intent": "This alarm can help to detect if the application is experiencing issues due to 5xx errors."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "FirstByteLatency",
+      "namespace": "AWS/S3"
+    },
+    "description": "The per-request time from the complete request being received by an Amazon S3 bucket to when the response starts to be returned.",
+    "recommendedStatistics": "Average, Sum, Min, Max (same as p100), Sample Count, any percentile between p0.0 and p100",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "TotalRequestLatency",
+      "namespace": "AWS/S3"
+    },
+    "description": "The elapsed per-request time from the first byte received to the last byte sent to an Amazon S3 bucket. This metric includes the time taken to receive the request body and send the response body, which is not included in `FirstByteLatency`.",
+    "recommendedStatistics": "Average, Sum, Min, Max (same as p100), Sample Count, any percentile between p0.0 and p100",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ReplicationLatency",
+      "namespace": "AWS/S3"
+    },
+    "description": "The maximum number of seconds by which the replication destination AWS Region is behind the source AWS Region for a given replication rule.",
+    "recommendedStatistics": "Max",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesPendingReplication",
+      "namespace": "AWS/S3"
+    },
+    "description": "The total number of bytes of objects pending replication for a given replication rule.",
+    "recommendedStatistics": "Max",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "OperationsPendingReplication",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of operations pending replication for a given replication rule.",
+    "recommendedStatistics": "Max",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "OperationsFailedReplication",
+      "namespace": "AWS/S3"
+    },
+    "description": "The number of operations that failed to replicate for a given replication rule.",
+    "recommendedStatistics": "Sum (total number of failed operations), Average (failure rate), Sample Count (total number of replication operations)",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps in understanding a replication failure. This metric tracks the status of new objects replicated using S3 CRR or S3 SRR, and also tracks existing objects replicated using S3 batch replication. See [Replication troubleshooting](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-troubleshoot.html) for more details.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "This metric emits a value of 0 for successful operations, and nothing when there are no replication operations carried out for the minute. When the metric emits a value greater than 0, the replication operation is unsuccessful."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "SourceBucket"
+          },
+          {
+            "name": "DestinationBucket"
+          },
+          {
+            "name": "RuleId"
+          }
+        ],
+        "intent": "This alarm is used to detect if there is a failed replication operation."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "BytesDropCountBlackhole",
+      "namespace": "AWS/TransitGateway"
+    },
+    "description": "The number of bytes dropped because they matched a `blackhole` route. If the dimension includes `TransitGatewayAttachment`, then this metric is specific to an attachment, else it is for all the attachments for a Transit Gateway.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesDropCountNoRoute",
+      "namespace": "AWS/TransitGateway"
+    },
+    "description": "The number of bytes dropped because they did not match a route. If the dimension includes `TransitGatewayAttachment` then this metric is specific to an attachment, else it is for all the attachments for a Transit Gateway.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesIn",
+      "namespace": "AWS/TransitGateway"
+    },
+    "description": "The number of bytes received by the transit gateway. If the dimension includes `TransitGatewayAttachment` then this metric is specific to an attachment, else it is for all the attachments for a Transit Gateway.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesOut",
+      "namespace": "AWS/TransitGateway"
+    },
+    "description": "The number of bytes sent from the transit gateway. If the dimension includes `TransitGatewayAttachment` then this metric is specific to an attachment, else it is for all the attachments for a Transit Gateway.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "PacketsIn",
+      "namespace": "AWS/TransitGateway"
+    },
+    "description": "The number of packets received by the transit gateway. If the dimension includes `TransitGatewayAttachment` then this metric is specific to an attachment, else it is for all the attachments for a Transit Gateway.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PacketsOut",
+      "namespace": "AWS/TransitGateway"
+    },
+    "description": "The number of packets sent by the transit gateway. If the dimension includes `TransitGatewayAttachment` then this metric is specific to an attachment, else it is for all the attachments for a Transit Gateway.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PacketDropCountBlackhole",
+      "namespace": "AWS/TransitGateway"
+    },
+    "description": "The number of packets dropped because they matched a `blackhole` route. If the dimension includes `TransitGatewayAttachment` then this metric is specific to an attachment, else it is for all the attachments for a Transit Gateway.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PacketDropCountNoRoute",
+      "namespace": "AWS/TransitGateway"
+    },
+    "description": "The number of packets dropped because they did not match a route. If the dimension includes `TransitGatewayAttachment` then this metric is specific to an attachment, else it is for all the attachments for a Transit Gateway.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PacketDropTTLExpired",
+      "namespace": "AWS/TransitGateway"
+    },
+    "description": "The number of packets dropped because the TTL expired. If the dimension includes `TransitGatewayAttachment` then this metric is specific to an attachment, else it is for all the attachments for a Transit Gateway.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "cluster_failed_node_count",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of failed worker nodes in the cluster. A node is considered failed if it is suffering from any node conditions. For more information, see Conditions in the Kubernetes documentation.",
+    "recommendedStatistics": "Average, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "cluster_node_count",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total number of worker nodes in the cluster.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "namespace_number_of_running_pods",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of pods running per namespace in the resource that is specified by the dimensions that you're using.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "node_cpu_limit",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The maximum number of CPU units that can be assigned to a single node in this cluster.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "node_cpu_reserved_capacity",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of CPU units that are reserved for node components, such as kubelet, kube-proxy, and Docker. Formula: `node_cpu_request / node_cpu_limit`. Note: `node_cpu_request` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects high CPU reservation on nodes in your EKS cluster. High CPU reservation might indicate that nodes are approaching their capacity for scheduling new workloads, which could lead to scheduling failures or resource contention.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold to 80% to provide adequate warning before nodes become fully reserved. This gives you time to scale the cluster or optimize workloads."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm helps ensure there's sufficient CPU capacity available for scheduling new pods and managing unexpected workload increases. When triggered, consider scaling your node groups or optimizing existing workloads."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "node_cpu_usage_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of CPU units being used on the nodes in the cluster.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "node_cpu_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total percentage of CPU units being used on the nodes in the cluster. Formula: `node_cpu_usage_total / node_cpu_limit`.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect high CPU utilization in worker nodes of the EKS cluster. If the utilization is consistently high, it might indicate a need for replacing your worker nodes with instances that have greater CPU or a need to scale the system horizontally.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "It is recommended to set the threshold at less than or equal to 80% to allow enough time to debug the issue before the system starts seeing impact."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm helps to monitor the CPU utilization of the worker nodes in the EKS cluster so that the system performance doesn't degrade."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "node_filesystem_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total percentage of file system capacity being used on nodes in the cluster. Formula: `node_filesystem_usage / node_filesystem_capacity`. Note: `node_filesystem_usage` and `node_filesystem_capacity` are not reported directly as metrics, but are fields in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect high file system utilization in the worker nodes of the EKS cluster. If the utilization is consistently high, you might need to update your worker nodes to have larger disk volume, or you might need to scale horizontally.",
+        "threshold": {
+          "justification": "If there's sufficient disk pressure (meaning that the disk is getting full), nodes are marked as not healthy, and the pods are evicted from the node. Pods on a node with disk pressure are evicted when the available file system is lower than the eviction thresholds set on the kubelet. Set the alarm threshold so that you have enough time to react before the node is evicted from the cluster."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm helps to monitor the filesystem utilization of the worker nodes in the EKS cluster. If the utilization reaches 100%, it can lead to application failure, disk I/O bottlenecks, pod eviction, or the node to become unresponsive entirely."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "node_memory_limit",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The maximum amount of memory, in bytes, that can be assigned to a single node in this cluster.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "node_memory_reserved_capacity",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of memory currently being used on the nodes in the cluster. Formula: `node_memory_request / node_memory_limit`. Note: `node_memory_request` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects when memory reservation on cluster nodes reaches critical levels. High memory reservation means limited capacity for scheduling new pods, which could lead to pod scheduling failures even when actual memory usage is moderate.",
+        "threshold": {
+          "staticValue": 85.0,
+          "justification": "Set the threshold to 85% to provide warning before the cluster becomes unable to schedule new workloads. This gives you time to scale the cluster or optimize workloads. Memory reservation affects scheduling decisions but doesn't affect runtime performance, so this threshold can be slightly higher than utilization thresholds."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 2,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm helps prevent scheduling failures by alerting when node memory reservation approaches capacity. When triggered, consider scaling your node groups horizontally, optimizing pod memory requests, or migrating workloads to balance resource distribution."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "node_memory_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of memory currently being used by the node or nodes. It is the percentage of node memory usage divided by the node memory limitation. Formula: `node_memory_working_set / node_memory_limit`.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps in detecting high memory utilization in worker nodes of the EKS cluster. If the utilization is consistently high, it might indicate a need to scale the number of pod replicas, or optimize your application.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "It is recommended to set the threshold at less than or equal to 80% to allow having enough time to debug the issue before the system starts seeing impact."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 2,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm helps to monitor the memory utilization of the worker nodes in the EKS cluster so that the system performance doesn't degrade."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "node_memory_working_set",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The amount of memory, in bytes, being used in the working set of the nodes in the cluster.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "node_network_total_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total number of bytes per second transmitted and received over the network per node in a cluster. Formula: `node_network_rx_bytes + node_network_tx_bytes`. Note: `node_network_rx_bytes` and `node_network_tx_bytes` are not reported directly as metrics, but are fields in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "node_number_of_running_containers",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of running containers per node in a cluster.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "node_number_of_running_pods",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of running pods per node in a cluster.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_cpu_reserved_capacity",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The CPU capacity that is reserved per pod in a cluster. Formula: `pod_cpu_request / node_cpu_limit`. Note: `pod_cpu_request` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm identifies namespaces with high CPU reservation relative to cluster capacity. Consistently high values may indicate resource allocation inefficiency, causing increased costs or preventing other workloads from scheduling.",
+        "threshold": {
+          "staticValue": 70.0,
+          "justification": "Set this threshold to 70% at the namespace level to identify potential resource monopolization by specific applications. This is a lower threshold than node-level thresholds because it's unusual for a single namespace to consume such a large portion of cluster CPU."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "Namespace"
+          }
+        ],
+        "intent": "This alarm helps identify potential resource allocation issues by monitoring namespaces that reserve disproportionate amounts of cluster CPU. When triggered, review the CPU requests for pods in the namespace and consider adjusting reservation levels based on actual utilization patterns."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "pod_cpu_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of CPU units being used by pods. Formula: `pod_cpu_usage_total / node_cpu_limit`.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects when pods in a namespace are consuming high CPU resources. Sustained high CPU utilization may lead to performance degradation, throttling, or affect other workloads sharing the same nodes.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set this threshold to 80% to identify when namespace workloads are approaching performance bottlenecks, while also avoiding false alarms from normal CPU spikes."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "Namespace"
+          }
+        ],
+        "intent": "This alarm identifies namespaces that have high actual CPU consumption. These namespace might need scaling or optimization. When the alarm is triggered, evaluate horizontal pod scaling, investigate CPU-intensive processes, or consider increasing CPU limits for critical workloads."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "pod_cpu_utilization_over_pod_limit",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of CPU units being used by pods relative to the pod limit. Formula: `pod_cpu_usage_total / pod_cpu_limit`.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps in detecting high CPU utilization in pods of the EKS cluster. If the utilization is consistently high, it might indicate a need to increase the CPU limit for the affected pod.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "It is recommended to set the threshold at less than or equal to 80% to allow having enough time to debug the issue before the system starts seeing impact."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "Namespace"
+          },
+          {
+            "name": "Service"
+          }
+        ],
+        "intent": "This alarm helps to monitor the CPU utilization of the pods belonging to a Kubernetes Service in the EKS cluster, so that you can quickly identify if a service's pod is consuming higher CPU than expected."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "pod_memory_reserved_capacity",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of memory that is reserved for pods. Formula: `pod_memory_request / node_memory_limit`. Note: `pod_memory_request` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects when a namespace has reserved a high percentage of cluster memory. High memory reservation by a single namespace may prevent other workloads from scheduling and indicate resource allocation imbalances.",
+        "threshold": {
+          "staticValue": 70.0,
+          "justification": "Set this threshold to 70% to identify potential resource monopolization by specific namespaces. This threshold is lower than node-level thresholds because it's unusual for a single namespace to consume such a large portion of cluster memory."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "Namespace"
+          }
+        ],
+        "intent": "This alarm helps maintain balanced resource allocation across namespaces. When triggered, review memory requests in the namespace, adjust based on actual utilization patterns, and consider implementing resource quotas to prevent individual namespaces from monopolizing cluster resources."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "pod_memory_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of memory currently being used by the pod or pods. Formula: `pod_memory_working_set / node_memory_limit`.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects high actual memory usage by pods in a namespace. Sustained high memory utilization can lead to pod OOMKills, evictions, and application instability, especially if memory usage continues to increase.",
+        "threshold": {
+          "staticValue": 75.0,
+          "justification": "Set this threshold to 75% to give you an early warning of memory pressure at the namespace level. Memory issues can escalate more rapidly than CPU issues and have more severe consequences (OOMKills), warranting a slightly lower alarm threshold."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 4,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "Namespace"
+          }
+        ],
+        "intent": "This alarm helps prevent memory-related failures by identifying namespaces with high memory consumption. When triggered, investigate for memory leaks, consider increasing memory limits for affected deployments, implement horizontal scaling, or optimize application memory usage."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "pod_memory_utilization_over_pod_limit",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of memory that is being used by pods relative to the pod limit. If any containers in the pod don't have a memory limit defined, this metric doesn't appear. Formula: `pod_memory_working_set / pod_memory_limit`.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps in detecting high memory utilization in pods of the EKS cluster. If the utilization is consistently high, it might indicate a need to increase the memory limit for the affected pod.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "It is recommended to set the threshold at less than or equal to 80% to allow having enough time to debug the issue before the system starts seeing impact."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "Namespace"
+          },
+          {
+            "name": "Service"
+          }
+        ],
+        "intent": "This alarm helps to monitor the memory utilization of the pods in the EKS cluster so that the system performance doesn't degrade."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "pod_cpu_usage_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of CPU units used by a pod.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_memory_working_set",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The memory in bytes that is currently being used by a pod.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_network_rx_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second being received over the network by the pod. Formula: `sum(pod_interface_network_rx_bytes)`. Note: `pod_interface_network_rx_bytes` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_network_tx_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second being transmitted over the network by the pod. Formula: `sum(pod_interface_network_tx_bytes)`. Note: `pod_interface_network_tx_bytes` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_number_of_container_restarts",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total number of container restarts in a pod.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "service_number_of_running_pods",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of pods running the service or services in the cluster.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_cpu_request",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The CPU requests for the pod. Formula: `sum(container_cpu_request)`. Note: `pod_cpu_request` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_memory_request",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The memory requests for the pod. Formula: `sum(container_memory_request)`. Note: `pod_memory_request` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_cpu_limit",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The CPU limit defined for the containers in the pod. If any containers in the pod don't have a CPU limit defined, this metric doesn't appear. Formula: `sum(container_cpu_limit)`. Note: `pod_cpu_limit` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_memory_limit",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The memory limit defined for the containers in the pod. If any containers in the pod don't have a memory limit defined, this metric doesn't appear. Formula: `sum(container_memory_limit)`. Note: `pod_cpu_limit` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_status_failed",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates that all containers in the pod have terminated, and at least one container has terminated with a non-zero status or was terminated by the system.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_status_ready",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates that all containers in the pod are ready, having reached the condition of `ContainerReady`.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_status_running",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates that all containers in the pod are running.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_status_scheduled",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates that the pod has been scheduled to a node.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_status_unknown",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates that status of the pod can't be obtained.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_status_pending",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates that the pod has been accepted by the cluster but one or more of the containers has not become ready yet.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm indicates pods remain stuck in pending state, which prevents applications from starting. Persistent pending pods often indicate: 1) Insufficient cluster resources - check node CPU/memory utilization 2) Pod scheduling constraints - verify node affinity/taints are configured correctly 3) PVC issues - check if PersistentVolumeClaims are bound. Use 'kubectl describe pod <pod-name>' to view scheduling events.",
+        "threshold": {
+          "staticValue": 3.0,
+          "justification": "Setting a threshold of 3 pending pods detects when multiple pods fail to schedule beyond normal deployment intervals. Adjust this threshold based on your deployment patterns and cluster size. Smaller environments may use lower thresholds (1-2), while large clusters with frequent deployments may require higher values (5+)."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 8,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "Namespace"
+          }
+        ],
+        "intent": "This alarm detects resource constraints or configuration issues that prevent pods from being scheduled and started. This is critical for application availability, especially during deployments or scaling events when new pods need to be scheduled quickly. It helps identify cluster capacity issues before they widely impact services."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "pod_status_succeeded",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates that all containers in the pod have successfully terminated and will not be restarted.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_number_of_containers",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reports the number of containers defined in the pod specification.",
+    "recommendedStatistics": "Maximum, Minimum, Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_number_of_running_containers",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reports the number of containers in the pod which are currently in the `Running` state.",
+    "recommendedStatistics": "Maximum, Minimum, Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_container_status_terminated",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reports the number of containers in the pod which are in the `Terminated` state.",
+    "recommendedStatistics": "Maximum, Minimum, Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_container_status_running",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reports the number of containers in the pod which are in the `Running` state.",
+    "recommendedStatistics": "Maximum, Minimum, Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_container_status_waiting",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reports the number of containers in the pod which are in the `Waiting` state.",
+    "recommendedStatistics": "Maximum, Minimum, Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_container_status_terminated_reason_oom_killed",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates a pod was terminated for exceeding the memory limit. This metric is only displayed when this issue occurs.",
+    "recommendedStatistics": "Maximum, Minimum, Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_interface_network_rx_dropped",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of packets which were received and subsequently dropped a network interface for the pod.",
+    "recommendedStatistics": "Maximum, Sum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_interface_network_tx_dropped",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of packets which were due to be transmitted but were dropped for the pod.",
+    "recommendedStatistics": "Maximum, Minimum, Sum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "container_cpu_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of CPU units being used by the container. Formula: `container_cpu_usage_total / node_cpu_limit`. Note: `container_cpu_utilization` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm identifies individual containers with high CPU consumption. Container-level CPU bottlenecks can indicate inefficient code, increased load, or resource constraints that may impact specific application components even when overall pod metrics appear healthy.",
+        "threshold": {
+          "staticValue": 85.0,
+          "justification": "Set this threshold to 85% to focus on containers that are genuinely CPU-constrained. Container-level metrics are more volatile than pod-level metrics, so this slightly higher threshold helps reduce false alarms while still catching problematic situations."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "Namespace"
+          },
+          {
+            "name": "PodName"
+          }
+        ],
+        "intent": "This alarm helps identify specific containers that may be experiencing CPU bottlenecks. When triggered, investigate the specific container's workload patterns, profile the application for CPU-intensive operations, adjust CPU limits as needed, or refactor inefficient code paths."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "container_cpu_utilization_over_container_limit",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of CPU units being used by the container relative to the container limit. If the container doesn't have a CPU limit defined, this metric doesn't appear. Formula: `container_cpu_usage_total / container_cpu_limit`. Note: `container_cpu_utilization_over_container_limit` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "container_memory_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of memory units being used by the container. Formula: `container_memory_working_set / node_memory_limit`. Note: `container_memory_utilization` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm identifies individual containers with high memory usage. High container memory utilization can indicate memory leaks, inefficient memory handling, or inadequate resource limits that may lead to OOMKills and restarts of specific containers.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set this threshold to 80% to detect containers approaching memory limits while allowing for normal fluctuations. Memory issues in individual containers can lead to application instability and should be addressed promptly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 2,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "Namespace"
+          },
+          {
+            "name": "PodName"
+          }
+        ],
+        "intent": "This alarm helps identify specific containers that may be experiencing memory issues before they cause application failures. When triggered, examine the container's memory usage patterns, check for memory leaks, optimize memory-intensive operations, or adjust container memory limits based on actual requirements."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "container_memory_utilization_over_container_limit",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of memory units being used by the container relative to the container limit. If the container doesn't have a memory limit defined, this metric doesn't appear. Formula: `container_memory_working_set / container_memory_limit`. Note: `container_memory_utilization_over_container_limit` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "container_memory_failures_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of memory allocation failures experienced by the container.",
+    "recommendedStatistics": "Maximum, Minimum, Sum, Average",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "container_filesystem_usage",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes consumed by the container on this filesystem.",
+    "recommendedStatistics": "Maximum, Minimum, Sum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "container_filesystem_available",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes available for the container on this filesystem.",
+    "recommendedStatistics": "Maximum, Minimum, Sum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "container_filesystem_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of the filesystem which is being consumed by the container. Formula: `container_memory_working_set / container_memory_limit`. Note: `container_filesystem_usage / container_filesystem_capacity` is not reported directly as a metric, but is a field in performance log events. For more information, see [Relevant fields in performance log events for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference-performance-entries-EKS.html).",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm indicates containers are approaching their filesystem capacity limits. When containers run out of storage space, they can't write new data, which typically causes application failures and errors. To troubleshoot: 1) Identify which files are consuming space using kubectl exec 2) Check for logs, temporary files, or data that can be cleaned up 3) Consider increasing the persistent volume size or implementing log rotation if appropriate.",
+        "threshold": {
+          "staticValue": 85.0,
+          "justification": "A threshold of 85% utilization provides adequate warning before containers experience write failures. At this threshold, you still have time to investigate and remediate while maintaining 15% headroom for temporary files or logs that might be generated during troubleshooting. For applications with high write rates, consider lowering the alarm threshold to 80%."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "Namespace"
+          },
+          {
+            "name": "PodName"
+          }
+        ],
+        "intent": "This alarm detects containers that are approaching storage capacity limits before they experience write failures. It's critical for stateful applications that write data or logs to their filesystems. These applications require immediate attention to prevent service disruption. For applications using persistent volumes, this alerts you to scale storage resources before users are impacted."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "replicas_desired",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of pods desired for a workload as defined in the workload specification.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "replicas_ready",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of pods for a workload that have reached the ready status.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_storage_objects",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of objects stored in etcd at the time of the last check.",
+    "recommendedStatistics": "Min, Max, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total number of API requests to the Kubernetes API server.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_duration_seconds",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Responce latency for API requests to the Kubernetes API server.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm indicates the Kubernetes API server is responding slowly to requests. Slow API responses directly impact all cluster operations including deployments, scaling, and pod scheduling. To troubleshoot: 1) Check apiserver logs for errors or warnings 2) Verify control plane has sufficient CPU and memory 3) Review etcd performance which often affects API server 4) For EKS clusters, contact AWS Support if issue persists.",
+        "threshold": {
+          "staticValue": 0.25,
+          "justification": "Setting a 250ms threshold provides a warning of API server slowness. While healthy clusters typically respond in under 100ms, brief spikes during high activity are normal. A 250ms average over multiple periods indicates a significant issue that requires immediate investigation before cluster operations are severely impacted."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 2,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm detects performance issues in the Kubernetes API server, which is the central management component for all cluster operations. Slow API server responses directly impact cluster usability, deployment times, and scaling operations. Critical for all Kubernetes clusters regardless of size or workload type."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_admission_controller_admission_duration_seconds",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Admission controller latency in seconds. An admission controller is code which intercepts requests to the Kubernetes API server.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "rest_client_request_duration_seconds",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reponse latency experienced by clients calling the Kubernetes API server. This metric is experimental and may change in future releases of Kubernetes.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm indicates that Kubernetes components are experiencing delays when communicating with the API server. High client-side latency can cause delayed pod scheduling, scaling operations, and status updates. To troubleshoot: 1) Check network connectivity between nodes and the control plane 2) Verify that the API server is not overloaded by checking CPU and memory 3) For EKS, confirm that security groups and VPC configurations allow proper communication.",
+        "threshold": {
+          "staticValue": 0.5,
+          "justification": "Setting a 500ms threshold detects significant communication delays between Kubernetes components. While brief spikes can occur during high load, sustained latency above 500ms indicates network issues or API server overload that will impact cluster operations."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 2,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm detects communication issues between Kubernetes components and the API server. High client-side latency indicates network problems, API server overload, or misconfiguration that can prevent proper cluster operation. Critical for all Kubernetes deployments to ensure control plane components can communicate effectively."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "rest_client_requests_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total number of API requests to the Kubernetes API server made by clients. This metric is experimental and may change in future releases of Kubernetes.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "etcd_request_duration_seconds",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Response latency of API calls to Etcd. This metric is experimental and may change in future releases of Kubernetes.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm indicates etcd operations are taking too long, which directly impacts cluster control plane performance. High etcd latency affects all API operations including pod scheduling, service updates, and configuration changes. To troubleshoot: 1) Check if etcd is experiencing disk I/O bottlenecks 2) Verify etcd nodes have sufficient resources 3) For EKS, consider upgrading cluster if persistent issues occur.",
+        "threshold": {
+          "staticValue": 0.1,
+          "justification": "Setting a 100ms threshold provides early warning of etcd performance degradation. While healthy etcd typically responds in under 50ms, brief spikes are normal. A 100ms average over multiple evaluation periods indicates a genuine problem that needs investigation before it impacts control plane functionality."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 2,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm detects performance degradation in the etcd database that powers Kubernetes. When etcd response times are high, all control plane operations slow down significantly, affecting scheduling, scaling, and overall cluster management. This is critical for all Kubernetes clusters regardless of workload type."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_storage_size_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Size of the storage database file physically allocated in bytes. This metric is experimental and may change in future releases of Kubernetes.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_storage_db_total_size_in_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Total size of the storage database file physically allocated in bytes. This metric is experimental and may change in future releases of Kubernetes.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_longrunning_requests",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of active long-running requests to the Kubernetes API server.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_current_inflight_requests",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of requests that are being processed by Kubernetes API server.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_admission_webhook_admission_duration_seconds",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Admission webhook latency in seconds. Admission webhooks are HTTP callbacks that receive admission requests and do something with them.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_admission_step_admission_duration_seconds",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Admission sub-step latency in seconds.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_requested_deprecated_apis",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Number of requests to deprecated APIs on the Kubernetes API server.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_total_5XX",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Number of requests to the Kubernetes API server which were responded to with a 5XX HTTP response code.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects an elevated rate of server-side errors (5XX) from the Kubernetes API server. API server errors can prevent cluster management operations, impact control plane functionality, and indicate underlying issues with etcd, API server resources, or other control plane components.",
+        "threshold": {
+          "staticValue": 10.0,
+          "justification": "A baseline threshold of 10 errors within the evaluation window provides a good starting point for detecting significant issues while avoiding false alarms from occasional errors. For production clusters, analyze your historical data to determine normal error rates and adjust accordingly. Large clusters may need a higher threshold, while small or critical clusters may warrant a lower threshold."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm monitors the health of your Kubernetes control plane by tracking API server errors. When triggered, investigate API server logs (in CloudWatch or through kubectl), check control plane resource utilization, verify etcd health, and look for recent changes to cluster configuration. Consider opening an AWS support case for managed EKS clusters with persistent API server errors."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_storage_list_duration_seconds",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Response latency of listing objects from Etc. This metric is experimental and may change in future releases of Kubernetes.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Seconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps detect high latency in API server list operations against etcd storage. Slow list operations can impact cluster operations, especially those requiring enumeration of resources. To troubleshoot, examine etcd performance, API server resources, and consider optimizing list queries.",
+        "threshold": {
+          "justification": "The threshold should be determined based on your cluster size and typical list operation patterns. Larger clusters may naturally have longer list durations. Monitor normal operation times and set thresholds that indicate genuine performance issues."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm monitors the duration of list operations against etcd to ensure efficient resource enumeration and detect potential performance issues in the storage layer."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_current_inqueue_requests",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number queued requests queued by the Kubernetes API server. This metric is experimental and may change in future releases of Kubernetes.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_flowcontrol_rejected_requests_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Number of requests rejected by API Priority and Fairness subsystem. This metric is experimental and may change in future releases of Kubernetes.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_flowcontrol_request_concurrency_limit",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of threads used by the currently executing requests in the API Priority and Fairness subsystem.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "node_status_allocatable_pods",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of pods that can be assigned to a node based on its allocatable resources, which is defined as the remainder of a node's capacity after accounting for system daemons reservations and hard eviction thresholds.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "node_status_capacity_pods",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of pods that can be assigned to a node based on its capacity.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "node_status_condition_ready",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates whether the node status condition `Ready` is true for Amazon EC2 nodes.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "node_status_condition_memory_pressure",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates whether the node status condition `MemoryPressure` is true.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "node_status_condition_pid_pressure",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates whether the node status condition `PIDPressure` is true.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "node_status_condition_disk_pressure",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates whether the node status condition `OutOfDisk` is true.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "node_status_condition_unknown",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates whether any of the node status conditions are Unknown.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "node_interface_network_rx_dropped",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of packets which were received and subsequently dropped by a network interface on the node.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "node_interface_network_tx_dropped",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of packets which were due to be transmitted but were dropped by a network interface on the node.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "node_diskio_io_service_bytes_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total number of bytes transferred by all I/O operations on the node.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "node_diskio_io_serviced_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total number of I/O operations on the node.",
+    "recommendedStatistics": "Maximum, Minimum, Average, Sum",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "node_filesystem_inodes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total number of inodes (used and unused) on a node.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "node_filesystem_inodes_free",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of unused inodes on a node.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "container_gpu_memory_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total frame buffer size, in bytes, on the GPU(s) allocated to the container.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "container_gpu_memory_used",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The bytes of frame buffer used on the GPU(s) allocated to the container.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "container_gpu_power_draw",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The power usage in watts of the GPU(s) allocated to the container.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "container_gpu_temperature",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The temperature in degrees celsius of the GPU(s) allocated to the container.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "container_gpu_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage utilization of the GPU(s) allocated to the container.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "container_gpu_memory_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of frame buffer used of the GPU(s) allocated to the container.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "node_gpu_memory_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total frame buffer size, in bytes, on the GPU(s) allocated to the node.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "node_gpu_memory_used",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The bytes of frame buffer used on the GPU(s) allocated to the node.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "node_gpu_power_draw",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The power usage in watts of the GPU(s) allocated to the node.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "node_gpu_temperature",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The temperature in degrees celsius of the GPU(s) allocated to the node.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "node_gpu_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage utilization of the GPU(s) allocated to the node.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "hyperpod_node_health_status_unschedulable",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates if a node is labeled as Unschedulable by Amazon SageMaker HyperPod. This means that the node is running deep health checks and is not available for running workloads.",
+    "recommendedStatistics": "Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "hyperpod_node_health_status_schedulable",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates if a node is labeled as Schedulable by Amazon SageMaker HyperPod. This means that the node has passed basic or deep health checks and is available for running workloads.",
+    "recommendedStatistics": "Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "hyperpod_node_health_status_unschedulable_pending_replacement",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates if a node is labeled as UnschedulablePendingReplacement by Amazon SageMaker HyperPod. This means that the node has failed deep health checks or health monitoring agent checks and requires a replacement. If automatic node recovery is enabled, the node will be automatically replaced by Amazon SageMaker HyperPod.",
+    "recommendedStatistics": "Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "hyperpod_node_health_status_unschedulable_pending_reboot",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Indicates if a node is labeled as UnschedulablePendingReboot by Amazon SageMaker HyperPod. This means that the node has failed deep health checks or health monitoring agent checks and requires a reboot. If automatic node recovery is enabled, the node will be automatically rebooted by Amazon SageMaker HyperPod.",
+    "recommendedStatistics": "Maximum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "node_gpu_memory_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of frame buffer used of the GPU(s) allocated to the node.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_gpu_memory_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The total frame buffer size, in bytes, on the GPU(s) allocated to the pod.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_gpu_memory_used",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The bytes of frame buffer used on the GPU(s) allocated to the pod.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_gpu_power_draw",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The power usage in watts of the GPU(s) allocated to the pod.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_gpu_temperature",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The temperature in degrees celsius of the GPU(s) allocated to the pod.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_gpu_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage utilization of the GPU(s) allocated to the pod.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_gpu_memory_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage of frame buffer used of the GPU(s) allocated to the pod.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "container_neuroncore_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage NeuronCore utilization of the cores allocated to the container during the captured period.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "container_neuroncore_memory_usage_constants",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the container that was used for constants during training or weights during inference.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "container_neuroncore_memory_usage_model_code",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the container that was used for the model's executable code.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "container_neuroncore_memory_usage_model_shared_scratchpad",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the container that was used for the scratchpad shared by the models - a memory region reserved for the models.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "container_neuroncore_memory_usage_runtime_memory",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the container that was used by the Neuron Runtime.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "container_neuroncore_memory_usage_tensors",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the container that was used for tensors.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "container_neuroncore_memory_usage_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Total amount of memory allocated to the container that was used in the neuroncore.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_neuroncore_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage NeuronCore utilization of the cores allocated to the pod during the captured period.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_neuroncore_memory_usage_constants",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the pod that was used for constants during training or weights during inference.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_neuroncore_memory_usage_model_code",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the pod that was used for the model's executable code.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_neuroncore_memory_usage_model_shared_scratchpad",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the pod that was used for the scratchpad shared by the models - a memory region reserved for the models.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_neuroncore_memory_usage_runtime_memory",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the pod that was used by the Neuron Runtime.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_neuroncore_memory_usage_tensors",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the pod that was used for tensors.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_neuroncore_memory_usage_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Total amount of memory allocated to the pod that was used in the neuroncore.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "node_neuroncore_utilization",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The percentage NeuronCore utilization of the cores allocated to the node during the captured period.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "node_neuroncore_memory_usage_constants",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the node that was used for constants during training or weights during inference.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "node_neuroncore_memory_usage_model_code",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the node that was used for the model's executable code.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "node_neuroncore_memory_usage_model_shared_scratchpad",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the node that was used for the scratchpad shared by the models - a memory region reserved for the models.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "node_neuroncore_memory_usage_runtime_memory",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the node that was used by the Neuron Runtime.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "node_neuroncore_memory_usage_tensors",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Amount of device memory allocated to the node that was used for tensors.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "node_neuroncore_memory_usage_total",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Total amount of memory allocated to the node that was used in the neuroncore.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "node_neurondevice_runtime_memory_used_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Total Neuron device memory usage in bytes allocated to the node.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "node_neuron_execution_latency",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The latency for an execution as measured by the Neuron Runtime.",
+    "recommendedStatistics": "Sum, Average, Maximum, Minimum",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "container_efa_rx_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second received by the EFA device(s) allocated to the container.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "container_efa_tx_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second transmitted by the EFA device(s) allocated to the container.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "container_efa_rx_dropped",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of packets which were received and subsequently dropped by the EFA device(s) allocated to the container.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "container_efa_rdma_read_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second received using remote direct memory access read operations by the EFA device(s) allocated to the container.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "container_efa_rdma_write_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second transmitted using remote direct memory access write operations by the EFA device(s) allocated to the container.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "container_efa_rdma_write_recv_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second received during remote direct memory access write operations by the EFA device(s) allocated to the container.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_efa_rx_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second received by the EFA device(s) allocated to the pod.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_efa_tx_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second transmitted by the EFA device(s) allocated to the pod.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_efa_rx_dropped",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of packets which were received and subsequently dropped by the EFA device(s) allocated to the pod.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_efa_rdma_read_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second received using remote direct memory access read operations by the EFA device(s) allocated to the pod.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_efa_rdma_write_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second transmitted using remote direct memory access write operations by the EFA device(s) allocated to the pod.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "pod_efa_rdma_write_recv_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second received during remote direct memory access write operations by the EFA device(s) allocated to the pod.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "node_efa_rx_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second received by the EFA device(s) allocated to the node.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "node_efa_tx_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second transmitted by the EFA device(s) allocated to the node.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "node_efa_rx_dropped",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of packets which were received and subsequently dropped by the EFA device(s) allocated to the node.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Count/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "node_efa_rdma_read_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second received using remote direct memory access read operations by the EFA device(s) allocated to the node.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "node_efa_rdma_write_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second transmitted using remote direct memory access write operations by the EFA device(s) allocated to the node.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "node_efa_rdma_write_recv_bytes",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of bytes per second received during remote direct memory access write operations by the EFA device(s) allocated to the node.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Bytes/Second"
+  },
+  {
+    "metricId": {
+      "metricName": "status_replicas_available",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of pods for a workload which are available. A pod is available when it has been ready for the `minReadySeconds` defined in the workload specification."
+  },
+  {
+    "metricId": {
+      "metricName": "status_replicas_unavailable",
+      "namespace": "ContainerInsights"
+    },
+    "description": "The number of pods for a workload which are unavailable. A pod is available when it has been ready for the `minReadySeconds` defined in the workload specification. Pods are unavailable if they have not met this criterion."
+  },
+  {
+    "metricId": {
+      "metricName": "pod_container_status_waiting_reason_crash_loop_back_off",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reports the number of containers in the pod which are pending because of a `CrashLoopBackOff` error, where a container repeatedly fails to start."
+  },
+  {
+    "metricId": {
+      "metricName": "pod_container_status_waiting_reason_create_container_config_error",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reports the number of containers in the pod which are pending with the reason `CreateContainerConfigError`. This is because of an error while creating the container configuration."
+  },
+  {
+    "metricId": {
+      "metricName": "pod_container_status_waiting_reason_create_container_error",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reports the number of containers in the pod which are pending with the reason `CreateContainerError` because of an error while creating the container."
+  },
+  {
+    "metricId": {
+      "metricName": "pod_container_status_waiting_reason_image_pull_error",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reports the number of containers in the pod which are pending because of `ErrImagePull`, `ImagePullBackOff`, or `InvalidImageName`. These situations are because of an error while pulling the container image."
+  },
+  {
+    "metricId": {
+      "metricName": "pod_container_status_waiting_reason_oom_killer",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reports the number of containers in the pod which are in the `Terminated` state. because of running out of memory (OOM killed)."
+  },
+  {
+    "metricId": {
+      "metricName": "pod_container_status_waiting_reason_start_error",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reports the number of containers in the pod which are pending with the reason being `StartError` because of an error while starting the container."
+  },
+  {
+    "metricId": {
+      "metricName": "pod_container_status_waiting_reason_oom_killed",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Reports the number of containers in the pod which are in the `Terminated` state. because of running out of memory (OOM killed)."
+  },
+  {
+    "metricId": {
+      "metricName": "apiserver_request_total_5xx",
+      "namespace": "ContainerInsights"
+    },
+    "description": "Number of requests to the Kubernetes API server which were responded to with a 5XX HTTP response code.",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm detects an elevated rate of server-side errors (5XX) from the Kubernetes API server. API server errors can prevent cluster management operations, impact control plane functionality, and indicate underlying issues with etcd, API server resources, or other control plane components.",
+        "threshold": {
+          "staticValue": 10.0,
+          "justification": "A baseline threshold of 10 errors within the evaluation window provides a good starting point for detecting significant issues while avoiding false alarms from occasional errors. For production clusters, analyze your historical data to determine normal error rates and adjust accordingly. Large clusters may need a higher threshold, while small or critical clusters may warrant a lower threshold."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "This alarm monitors the health of your Kubernetes control plane by tracking API server errors. When triggered, investigate API server logs (in CloudWatch or through kubectl), check control plane resource utilization, verify etcd health, and look for recent changes to cluster configuration. Consider opening an AWS support case for managed EKS clusters with persistent API server errors."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "InvocationAttemptCount",
+      "namespace": "AWS/Scheduler"
+    },
+    "description": "Emitted for every invocation attempt. Use this metric to check that EventBridge Scheduler is attempting to invoke your schedules, and to see when invocations approach your account quotas.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "TargetErrorCount",
+      "namespace": "AWS/Scheduler"
+    },
+    "description": "Emitted when the target returns an exception after EventBridge Scheduler calls the target API. Use this to check when delivery to a target fails.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "TargetErrorThrottledCount",
+      "namespace": "AWS/Scheduler"
+    },
+    "description": "Emitted when target invocation fails due to API throttling by the target. Use this to diagnose delivery failures when the underlying reason is the target API throttling calls made by EventBridge Scheduler.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you identify target throttling. To avoid target throttling error, consider [configuring flexible time windows](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-schedule-flexible-time-windows.html) to spread your invocation load or increasing limits with the target service.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "If the target throttling error is consistently greater than 0, schedule delivery is delayed. For some systems, target throttling errors for a brief period of time might be normal, while for others, it might be a cause of concern. Set this alarm's threshold, datapointsToAlarm, and evaluationPeriods accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "notBreaching",
+        "dimensions": [],
+        "intent": "This alarm is used to detect target throttling errors, which can cause schedule delays."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "InvocationThrottleCount",
+      "namespace": "AWS/Scheduler"
+    },
+    "description": "Emitted when EventBridge Scheduler throttles a target invocation because it exceeds your service quotas set by EventBridge Scheduler. Use this to determine when you have exceeded your invocations throttle limit quota. For more information about service quotas, see [Quotas for Amazon EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/scheduler-quotas.html).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you identify invocation throttling by EventBridge Scheduler. To avoid invocation throttling errors, consider [configuring flexible time windows](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-schedule-flexible-time-windows.html) to spread your invocation load or [increasing invocations throttle limit](https://docs.aws.amazon.com/scheduler/latest/UserGuide/scheduler-quotas.html).",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "If the invocation throttling is consistently greater than 0, schedule delivery is delayed. For some systems, invocation throttling errors for a brief period of time might be normal, while for others, it might be a cause of concern. Set this alarm's threshold, datapointsToAlarm, and evaluationPeriods accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "notBreaching",
+        "dimensions": [],
+        "intent": "This alarm is used to detect EventBridge Scheduler invocation throttling errors, which can cause schedule delays."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "InvocationDroppedCount",
+      "namespace": "AWS/Scheduler"
+    },
+    "description": "Emitted when EventBridge Scheduler stops attempting to invoke the target after a schedule's retry policy has been exhausted. For more information about retry policies, see [RetryPolicy](https://docs.aws.amazon.com/scheduler/latest/APIReference/API_RetryPolicy.html) in the EventBridge Scheduler API Reference.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you identify invocations dropped by EventBridge Scheduler. Consider investigating by [configuring a DLQ](https://docs.aws.amazon.com/scheduler/latest/UserGuide/configuring-schedule-dlq.html) for the schedule.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "Set the threshold to 0 to detect dropped invocations."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 1,
+        "datapointsToAlarm": 1,
+        "treatMissingData": "notBreaching",
+        "dimensions": [],
+        "intent": "This alarm is used to detect dropped invocations by EventBridge Scheduler. If you have configured a DLQ correctly on all of your schedules, dropped invocations will appear in the DLQ and you can skip setting up this alarm."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "InvocationsSentToDeadLetterCount",
+      "namespace": "AWS/Scheduler"
+    },
+    "description": "Emitted for every successful delivery to a schedule's DLQ. Use this to determine when events are sent to a DLQ, then check the event delivered to the schedule's DLQ for additional details that help you determine the cause of the failure.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "InvocationsFailedToBeSentToDeadLetterCount",
+      "namespace": "AWS/Scheduler"
+    },
+    "description": "Emitted when EventBridge Scheduler cannot deliver an event to the DLQ.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you identify invocations that were failed to be sent to the configured DLQ by EventBridge Scheduler. If the metric is consistently greater than 0, modify your DLQ configuration to resolve the issue. Use InvocationsFailedToBeSentToDeadLetterCount_<error_code> metrics to determine the issue.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "Set the threshold to 0 to detect any invocations that were failed to be sent to the configured DLQ. Retryable errors also show up in this metric, so datapointsToAlarm for this alarm has been set to 15."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "notBreaching",
+        "dimensions": [],
+        "intent": "This alarm is used to detect invocations failed to be sent to the configured DLQ by EventBridge Scheduler."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "InvocationsSentToDeadLetterCount_Truncated_MessageSizeExceeded",
+      "namespace": "AWS/Scheduler"
+    },
+    "description": "Emitted when the payload of the event sent to the DLQ exceeds the maximum size allowed by Amazon SQS, and EventBridge Scheduler truncates the payload you specify in the `Input` attribute of a schedule.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfMessagesPublished",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The number of messages published to your Amazon SNS topics.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm can detect when the number of SNS messages published is too low. For troubleshooting, check why the publishers are sending less traffic.",
+        "threshold": {
+          "justification": "The number of messages published should be in line with the expected number of published messages for your application. You can also analyze the historical data, trends and traffic to find the right threshold."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "TopicName"
+          }
+        ],
+        "intent": "This alarm helps you proactively monitor and detect significant drops in notification publishing. This helps you identify potential issues with your application or business processes, so that you can take appropriate actions to maintain the expected flow of notifications. You should create this alarm if you expect your system to have a minimum traffic that it is serving."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfNotificationsDelivered",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The number of messages successfully delivered from your Amazon SNS topics to subscribing endpoints. For a delivery attempt to succeed, the endpoint's subscription must accept the message. A subscription accepts a message if a.) it lacks a filter policy or b.) its filter policy includes attributes that match those assigned to the message. If the subscription rejects the message, the delivery attempt isn't counted for this metric.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm can detect when the number of SNS messages delivered is too low. This could be because of unintentional unsubscribing of an endpoint, or because of an SNS event that causes messages to experience delay.",
+        "threshold": {
+          "justification": "The number of messages delivered should be in line with the expected number of messages produced and the number of consumers. You can also analyze the historical data, trends and traffic to find the right threshold."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "TopicName"
+          }
+        ],
+        "intent": "This alarm helps you detect a drop in the volume of messages delivered. You should create this alarm if you expect your system to have a minimum traffic that it is serving."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfNotificationsFailed",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The number of messages that Amazon SNS failed to deliver. For Amazon SQS, email, SMS, or mobile push endpoints, the metric increments by 1 when Amazon SNS stops attempting message deliveries. For HTTP or HTTPS endpoints, the metric includes every failed delivery attempt, including retries that follow the initial attempt. For all other endpoints, the count increases by 1 when the message fails to deliver (regardless of the number of attempts). This metric does not include messages that were rejected by subscription filter policies. You can control the number of retries for HTTP endpoints. For more information, see [Amazon SNS message delivery retries](https://docs.aws.amazon.com/sns/latest/dg/sns-message-delivery-retries.html).",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm can detect when the number of failed SNS messages is too high. To troubleshoot failed notifications, enable logging to CloudWatch Logs. Checking the logs can help you find which subscribers are failing, as well as the status codes they are returning.",
+        "threshold": {
+          "justification": "The recommended threshold value for this alarm is highly dependent on the impact of failed notifications. Review the SLAs provided to your end users, fault tolerance and criticality of notifications and analyze historical data, and then select a threshold accordingly. The number of notifications failed should be 0 for topics that have only SQS, Lambda or Firehose subscriptions."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TopicName"
+          }
+        ],
+        "intent": "This alarm helps you proactively find issues with the delivery of notifications and take appropriate actions to address them."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfNotificationsFilteredOut",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The number of messages that were rejected by subscription filter policies. A filter policy rejects a message when the message attributes don't match the policy attributes.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfNotificationsFilteredOut-MessageAttributes",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The number of messages that were rejected by subscription filter policies for attribute-based filtering.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfNotificationsFilteredOut-MessageBody",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The number of messages that were rejected by subscription filter policies for payload-based filtering.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfNotificationsFilteredOut-InvalidAttributes",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The number of messages that were rejected by subscription filter policies because the messages' attributes are invalid – for example, because the attribute JSON is incorrectly formatted.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor and resolve potential problems with the publisher or subscribers. Check if a publisher is publishing messages with invalid attributes or if an inappropriate filter is applied to a subscriber. You can also analyze CloudWatch Logs to help find the root cause of the issue.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "Invalid attributes are almost always a mistake by the publisher. We recommend to set the threshold to 0 because invalid attributes are not expected in a healthy system."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TopicName"
+          }
+        ],
+        "intent": "The alarm is used to detect if the published messages are not valid or if inappropriate filters have been applied to a subscriber."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfNotificationsFilteredOut-NoMessageAttributes",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The number of messages that were rejected by subscription filter policies because the messages have no attributes.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfNotificationsFilteredOut-InvalidMessageBody",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The number of messages that were rejected by subscription filter policies because the message body is invalid for filtering – for example, invalid JSON message body.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor and resolve potential problems with the publisher or subscribers. Check if a publisher is publishing messages with invalid message bodies, or if an inappropriate filter is applied to a subscriber. You can also analyze CloudWatch Logs to help find the root cause of the issue.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "Invalid message bodies are almost always a mistake by the publisher. We recommend to set the threshold to 0 because invalid message bodies are not expected in a healthy system."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TopicName"
+          }
+        ],
+        "intent": "The alarm is used to detect if the published messages are not valid or if inappropriate filters have been applied to a subscriber."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfNotificationsRedrivenToDlq",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The number of messages that have been moved to a dead-letter queue.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor the number of messages that are moved to a dead-letter queue.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "In a healthy system of any subscriber type, messages should not be moved to the dead-letter queue. We recommend that you be notified if any messages land in the queue, so that you can identify and address the root cause, and potentially redrive the messages in the dead-letter queue to prevent data loss."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TopicName"
+          }
+        ],
+        "intent": "The alarm is used to detect messages that moved to a dead-letter queue. We recommend that you create this alarm when SNS is coupled with SQS, Lambda or Firehose."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfNotificationsFailedToRedriveToDlq",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The number of messages that couldn't be moved to a dead-letter queue.",
+    "recommendedStatistics": "Sum, Average",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor messages that couldn't be moved to a dead-letter queue. Check whether your dead-letter queue exists and that it's configured correctly. Also, verify that SNS has permissions to access the dead-letter queue. Refer to [dead-letter queue documentation](https://docs.aws.amazon.com/sns/latest/dg/sns-dead-letter-queues.html) to learn more.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "It's almost always a mistake if messages can't be moved to the dead-letter queue. The recommendation for the threshold is 0, meaning all messages that fail processing must be able to reach the dead-letter queue when the queue has been configured."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TopicName"
+          }
+        ],
+        "intent": "The alarm is used to detect messages that couldn't be moved to a dead-letter queue."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "PublishSize",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The size of messages published.",
+    "recommendedStatistics": "Minimum, Maximum, Average and Count",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "SMSMonthToDateSpentUSD",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The charges you have accrued since the start of the current calendar month for sending SMS messages. You can set an alarm for this metric to know when your month-to-date charges are close to the monthly SMS spend quota for your account. When Amazon SNS determines that sending an SMS message would incur a cost that exceeds this quota, it stops publishing SMS messages within minutes. For information about setting your monthly SMS spend quota, or for information about requesting a spend quota increase with AWS, see [Setting SMS messaging preferences in Amazon SNS](https://docs.aws.amazon.com/sns/latest/dg/sms_preferences.html).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "USD",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "The alarm helps to monitor if you have a sufficient quota in your account for SNS to be able to deliver messages. If you reach your quota, SNS won't be able to deliver SMS messages. For information about setting your monthly SMS spend quota, or for information about requesting a spend quota increase with AWS, see [Setting SMS messaging preferences](https://docs.aws.amazon.com/sns/latest/dg/sms_preferences.html).",
+        "threshold": {
+          "justification": "Set the threshold in accordance with the quota (Account spend limit) for the account. Choose a threshold which informs you early enough that you are reaching your quota limit so that you have time to request an increase."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "TopicName"
+          }
+        ],
+        "intent": "This alarm is used to detect if you have a sufficient quota in your account for your SMS messages to be delivered successfully."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "SMSSuccessRate",
+      "namespace": "AWS/SNS"
+    },
+    "description": "The rate of successful SMS message deliveries.",
+    "recommendedStatistics": "Sum, Average, Data Samples",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor the rate of failing SMS message deliveries. You can set up [Cloudwatch Logs](https://docs.aws.amazon.com/sns/latest/dg/sms_stats_cloudwatch.html) to understand the nature of the failure and take action based on that.",
+        "threshold": {
+          "justification": "Set the threshold for the alarm in line with your tolerance for failing SMS message deliveries."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "TopicName"
+          }
+        ],
+        "intent": "This alarm is used to detect failing SMS message deliveries."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "TunnelState",
+      "namespace": "AWS/VPN"
+    },
+    "description": "The state of the tunnels. For static VPNs, 0 indicates DOWN and 1 indicates UP. For BGP VPNs, 1 indicates ESTABLISHED and 0 is used for all other states. For both types of VPNs, values between 0 and 1 indicate at least one tunnel is not UP.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Fractional value between 0 and 1",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you understand if the state of one or more tunnels is DOWN. For troubleshooting, see [VPN tunnel troubleshooting](https://repost.aws/knowledge-center/vpn-tunnel-troubleshooting).",
+        "threshold": {
+          "staticValue": 1.0,
+          "justification": "A value less than 1 indicates that at least one tunnel is in DOWN state."
+        },
+        "period": 300,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Minimum",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "VpnId"
+          }
+        ],
+        "intent": "This alarm is used to detect if at least one tunnel is in the DOWN state for this VPN, so that you can troubleshoot the impacted VPN. This alarm will always be in the ALARM state for networks that only have a single tunnel configured."
+      },
+      {
+        "alarmDescription": "This alarm helps you understand if the state of this tunnel is DOWN. For troubleshooting, see [VPN tunnel troubleshooting](https://repost.aws/knowledge-center/vpn-tunnel-troubleshooting).",
+        "threshold": {
+          "staticValue": 1.0,
+          "justification": "A value less than 1 indicates that the tunnel is in DOWN state."
+        },
+        "period": 300,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Minimum",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "TunnelIpAddress"
+          }
+        ],
+        "intent": "This alarm is used to detect if the tunnel is in the DOWN state, so that you can troubleshoot the impacted VPN. This alarm will always be in the ALARM state for networks that only have a single tunnel configured."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "TunnelDataIn",
+      "namespace": "AWS/VPN"
+    },
+    "description": "The bytes received on the AWS side of the connection through the VPN tunnel from a customer gateway. Each metric data point represents the number of bytes received after the previous data point. Use the Sum statistic to show the total number of bytes received during the period. This metric counts the data after decryption.",
+    "recommendedStatistics": "Sum, Maximum, Minimum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "TunnelDataOut",
+      "namespace": "AWS/VPN"
+    },
+    "description": "The bytes sent from the AWS side of the connection through the VPN tunnel to the customer gateway. Each metric data point represents the number of bytes sent after the previous data point. Use the Sum statistic to show the total number of bytes sent during the period. This metric counts the data before encryption.",
+    "recommendedStatistics": "Sum, Maximum, Minimum, Average",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "AllRequests",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The total number of HTTP requests made to an Amazon S3 bucket by using an Object Lambda Access Point.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "GetRequests",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of HTTP `GET` requests made for objects by using an Object Lambda Access Point. This metric does not include list operations.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesUploaded",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of bytes uploaded to an Amazon S3 bucket by using an Object Lambda Access Point, where the request includes a body.",
+    "recommendedStatistics": "Average (bytes per request), Sum (bytes per period), Sample Count, Min, Max (same as p100), any percentile between p0.0 and p99.9",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "PostRequests",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of HTTP `POST` requests made to an Amazon S3 bucket by using an Object Lambda Access Point.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "PutRequests",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of HTTP `PUT` requests made for objects in an Amazon S3 bucket by using an Object Lambda Access Point.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DeleteRequests",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of HTTP `DELETE` requests made for objects in an Amazon S3 bucket by using an Object Lambda Access Point. This metric includes [DeleteObjects](https://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html) requests. This metric shows the number of requests made, not the number of objects deleted.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesDownloaded",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of bytes downloaded for requests made to an Amazon S3 bucket by using an Object Lambda Access Point, where the response includes a body.",
+    "recommendedStatistics": "Average (bytes per request), Sum (bytes per period), Sample Count, Min, Max (same as p100), any percentile between p0.0 and p99.9",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "FirstByteLatency",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The per-request time from the complete request being received by an Amazon S3 bucket through an Object Lambda Access Point to when the response starts to be returned. This metric is dependent on the AWS Lambda function's running time to transform the object before the function returns the bytes to the Object Lambda Access Point.",
+    "recommendedStatistics": "Average, Sum, Min, Max (same as p100), Sample Count, any percentile between p0.0 and p100",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "TotalRequestLatency",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The elapsed per-request time from the first byte received to the last byte sent to an Object Lambda Access Point. This metric includes the time taken to receive the request body and send the response body, which is not included in `FirstByteLatency`.",
+    "recommendedStatistics": "Average, Sum, Min, Max (same as p100), Sample Count, any percentile between p0.0 and p100",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "HeadRequests",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of HTTP `HEAD` requests made to an Amazon S3 bucket by using an Object Lambda Access Point.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ListRequests",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of HTTP `GET` requests that list the contents of an Amazon S3 bucket. This metric includes both `ListObjects` and `ListObjectsV2` operations.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "4xxErrors",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of HTTP 4xx client error status code requests made to an Amazon S3 bucket by using an Object Lambda Access Point with a value of either 0 or 1. The Average statistic shows the error rate, and the Sum statistic shows the count of that type of error, during each period.",
+    "recommendedStatistics": "Average (reports per request), Sum (reports per period), Min, Max, Sample Count",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps us report the total number of 4xx error status code that are made in response to client requests. [Enabling S3 server access logging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html) on a temporary basis will help you to pinpoint the issue's origin using the fields HTTP status and Error Code.",
+        "threshold": {
+          "staticValue": 0.05,
+          "justification": "We recommend setting the threshold to detect if more than 5% of total requests are getting 4XXError. Frequently occurring 4XX errors should be alarmed. However, setting a very low value for the threshold can cause alarm to be too sensitive. You can also tune the threshold to suit to the load of the requests, accounting for an acceptable level of 4XX errors. You can also analyze historical data to find the acceptable error rate for the application workload, and then tune the threshold accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "AccessPointName"
+          },
+          {
+            "name": "DataSourceARN"
+          }
+        ],
+        "intent": "This alarm is used to create a baseline for typical 4xx error rates so that you can look into any abnormalities that might indicate a setup issue."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "5xxErrors",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of HTTP 5xx server error status code requests made to an Amazon S3 bucket by using an Object Lambda Access Point with a value of either 0 or 1. The Average statistic shows the error rate, and the Sum statistic shows the count of that type of error, during each period.",
+    "recommendedStatistics": "Average (reports per request), Sum (reports per period), Min, Max, Sample Count",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect high number of server-side errors. These errors indicate that a client made a request that the server couldn’t complete. These errors might be caused by an issue with S3, check [AWS service health dashboard](https://health.aws.amazon.com/health/status) for the status of AWS S3 in your Region. This can help you correlate the issue your application is facing because of S3. For information to help you efficiently handle or reduce these errors, see [Optimizing performance design patterns](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance-design-patterns.html#optimizing-performance-timeouts-retries).",
+        "threshold": {
+          "staticValue": 0.05,
+          "justification": "We recommend setting the threshold to detect if more than 5% of total requests are getting 5XX errors. However, you can tune the threshold to suit the traffic of the requests, as well as acceptable error rates. You can also analyze historical data to see what is the acceptable error rate for the application workload, and tune the threshold accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "AccessPointName"
+          },
+          {
+            "name": "DataSourceARN"
+          }
+        ],
+        "intent": "This alarm can help to detect if the application is experiencing issues due to 5xx errors."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ProxiedRequests",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of HTTP requests to an Object Lambda Access Point that return the standard Amazon S3 API response. (Such requests do not have a Lambda function configured.)",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "InvokedLambda",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of HTTP requests to an S3 object where a Lambda function was invoked.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "LambdaResponseRequests",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of `WriteGetObjectResponse` requests made by the Lambda function. This metric applies only to `GetObject` requests."
+  },
+  {
+    "metricId": {
+      "metricName": "LambdaResponse4xx",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of HTTP 4xx client errors that occur when calling `WriteGetObjectResponse` from a Lambda function. This metric provides the same information as `4xxErrors`, but only for `WriteGetObjectResponse` calls.",
+    "recommendedStatistics": "Average (reports per request), Sum (reports per period), Min, Max, Sample Count",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect and diagnose failures (500s) in calls to S3 Object Lambda. These errors can be caused by errors or misconfigurations in the Lambda function responsible for responding to your requests. Investigating the CloudWatch Log Streams of the Lambda function associated with the Object Lambda Access Point can help you pinpoint the issue's origin based on the response from S3 Object Lambda.",
+        "threshold": {
+          "staticValue": 0.05,
+          "justification": "We recommend setting the threshold to detect if more than 5% of total requests are getting 4XXError. Frequently occurring 4XX errors should be alarmed. However, setting a very low value for the threshold can cause alarm to be too sensitive. You can also tune the threshold to suit to the load of the requests, accounting for an acceptable level of 4XX errors. You can also analyze historical data to find the acceptable error rate for the application workload, and then tune the threshold accordingly."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "AccessPointName"
+          },
+          {
+            "name": "DataSourceARN"
+          }
+        ],
+        "intent": "This alarm is used to detect 4xx client errors for WriteGetObjectResponse calls."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "LambdaResponse5xx",
+      "namespace": "AWS/S3ObjectLambda"
+    },
+    "description": "The number of HTTP 5xx server errors that occur when calling `WriteGetObjectResponse` from a Lambda function. This metric provides the same information as `5xxErrors`, but only for `WriteGetObjectResponse` calls."
+  },
+  {
+    "metricId": {
+      "metricName": "CPUReservation",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The percentage of CPU units that are reserved in the cluster or service. The CPU reservation ( filtered by `ClusterName`) is measured as the total CPU units that are reserved by Amazon ECS tasks on the cluster, divided by the total CPU units for all of the Amazon EC2 instances registered in the cluster. Only Amazon EC2 instances in `ACTIVE` or `DRAINING` status will affect CPU reservation metrics. The metric is only supported for tasks hosted on an Amazon EC2 instance.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Average, Minimum, Maximum",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect a high CPU reservation of the ECS cluster. High CPU reservation might indicate that the cluster is running out of registered CPUs for the task. To troubleshoot, you can add more capacity, you can scale the cluster, or you can set up auto scaling.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold for CPU reservation to 80%. Alternatively, you can choose a lower value based on cluster characteristics."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "The alarm is used to detect whether the total number of CPU units reserved by tasks on the cluster is reaching the total CPU units registered for the cluster. This helps you know when to scale up the cluster. Reaching the total CPU units for the cluster can result in running out of CPU for tasks. If you have EC2 capacity providers managed scaling turned on, or you have associated Fargate to capacity providers, then this alarm is not recommended."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "CPUUtilization",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The percentage of CPU units that is used by the cluster or service. The cluster-level CPU utilization ( filtered by `ClusterName`) is measured as the total CPU units that are in use by Amazon ECS tasks on the cluster, divided by the total CPU units for all of the Amazon EC2 instances registered in the cluster. Only Amazon EC2 instances in `ACTIVE` or `DRAINING` status will affect CPU reservation metrics. The cluster-level metric is only supported for tasks hosted on an Amazon EC2 instance. The service-level CPU utilization ( filtered by `ClusterName`, `ServiceName`) is measured as the total CPU units in use by the tasks that belong to the service, divided by the total number of CPU units that are reserved for the tasks that belong to the service. The service-level metric is supported for tasks hosted on Amazon EC2 instances and Fargate.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Average, Minimum, Maximum",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect a high CPU utilization of the ECS service. If there is no ongoing ECS deployment, a maxed-out CPU utilization might indicate a resource bottleneck or application performance problems. To troubleshoot, you can increase the CPU limit.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "The service metrics for CPU utilization might exceed 100% utilization. However, we recommend that you monitor the metric for high CPU utilization to avoid impacting other services. Set the threshold to about 80%. We recommend that you update your task definitions to reflect actual usage to prevent future issues with other services."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "ServiceName"
+          }
+        ],
+        "intent": "This alarm is used to detect high CPU utilization for the ECS service. Consistent high CPU utilization can indicate a resource bottleneck or application performance problems."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "MemoryReservation",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The percentage of memory that is reserved by running tasks in the cluster. Cluster memory reservation is measured as the total memory that is reserved by Amazon ECS tasks on the cluster, divided by the total amount of memory for all of the Amazon EC2 instances registered in the cluster. This metric can only be filtered by `ClusterName`. Only Amazon EC2 instances in `ACTIVE` or `DRAINING` status will affect memory reservation metrics. The cluster level memory reservation metric is only supported for tasks hosted on an Amazon EC2 instance. Note: When calculating memory utilization, if `MemoryReservation` is specified, it's used in the calculation instead of total memory.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Average, Minimum, Maximum",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect a high memory reservation of the ECS cluster. High memory reservation might indicate a resource bottleneck for the cluster. To troubleshoot, analyze the service task for performance to see if memory utilization of the task can be optimized.  Also, you can register more memory or set up auto scaling.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Set the threshold for memory reservation to 80%. You can adjust this to a lower value based on cluster characteristics."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          }
+        ],
+        "intent": "The alarm is used to detect whether the total memory units reserved by tasks on the cluster is reaching the total memory units registered for the cluster. This can help you know when to scale up the cluster. Reaching the total memory units for the cluster can cause the cluster to be unable to launch new tasks. If you have EC2 capacity providers managed scaling turned on or you have associated Fargate to capacity providers, this alarm is not recommended."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "MemoryUtilization",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The percentage of memory in use by the cluster or service. The cluster-level memory utilization (filtered by `ClusterName`) is measured as the total memory in use by Amazon ECS tasks on the cluster, divided by the total memory for all of the Amazon EC2 instances registered in the cluster. Only Amazon EC2 instances in `ACTIVE` or `DRAINING` status will affect memory utilization metrics. The cluster-level metric is only supported for tasks hosted on an Amazon EC2 instance. The service-level memory utilization (filtered by `ClusterName`, `ServiceName`) is measured as the total memory in use by the tasks that belong to the service, divided by the total memory reserved for the tasks that belong to the service. The service-level metric is supported for tasks hosted on Amazon EC2 instances and Fargate.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Average, Minimum, Maximum",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect a high memory utilization of the ECS service. If there is no ongoing ECS deployment, a maxed-out memory utilization might indicate a resource bottleneck or application performance problems. To troubleshoot, you can increase the memory limit.",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "The service metrics for memory utilization might exceed 100% utilization. However, we recommend that you monitor the metric for high memory utilization to avoid impacting other services. Set the threshold to about 80%. We recommend that you update your task definitions to reflect actual usage to prevent future issues with other services."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "ServiceName"
+          }
+        ],
+        "intent": "This alarm is used to detect high memory utilization for the ECS service. Consistent high memory utilization can indicate a resource bottleneck or application performance problems."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "GPUReservation",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The percentage of total available GPUs that are reserved by running tasks in the cluster. The cluster level GPU reservation metric is measured as the number of GPUs reserved by Amazon ECS tasks on the cluster, divided by the total number of GPUs that was available on all of the Amazon EC2 instances with GPUs registered in the cluster. Only Amazon EC2 instances in `ACTIVE` or `DRAINING` status will affect GPU reservation metrics.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Average, Minimum, Maximum"
+  },
+  {
+    "metricId": {
+      "metricName": "ActiveConnectionCount",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The total number of concurrent connections active from clients to the Amazon ECS Service Connect proxies that run in tasks that share the selected `DiscoveryName`. This metric is only available if you have configured Amazon ECS Service Connect.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Average, Minimum, Maximum, Sum"
+  },
+  {
+    "metricId": {
+      "metricName": "NewConnectionCount",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The total number of new connections established from clients to the Amazon ECS Service Connect proxies that run in tasks that share the selected `DiscoveryName`. This metric is only available if you have configured Amazon ECS Service Connect.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Average, Minimum, Maximum, Sum"
+  },
+  {
+    "metricId": {
+      "metricName": "ProcessedBytes",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The total number of bytes of inbound traffic processed by the Service Connect proxies. This metric is only available if you have configured Amazon ECS Service Connect.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Average, Minimum, Maximum, Sum"
+  },
+  {
+    "metricId": {
+      "metricName": "RequestCount",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The number of inbound traffic requests processed by the Service Connect proxies. This metric is only available if you have configured Amazon ECS Service Connect. You also need to configure `appProtocol` in the port mapping in your task definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Average, Minimum, Maximum, Sum"
+  },
+  {
+    "metricId": {
+      "metricName": "GrpcRequestCount",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The number of gRPC inbound traffic requests processed by the Service Connect proxies. This metric is only available if you have configured Amazon ECS Service Connect and the `appProtocol` is `GRPC` in the port mapping in the task definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Average, Minimum, Maximum, Sum"
+  },
+  {
+    "metricId": {
+      "metricName": "HTTPCode_Target_2XX_Count",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The number of HTTP response codes with numbers 200 to 299 generated by the applications in these tasks. These tasks are the targets. This metric only counts the responses sent to the Service Connect proxies by the applications in these tasks, not responses sent directly. This metric is only available if you have configured Amazon ECS Service Connect and the `appProtocol` is `HTTP` or `HTTP2` in the port mapping in the task definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Average, Minimum, Maximum, Sum"
+  },
+  {
+    "metricId": {
+      "metricName": "HTTPCode_Target_3XX_Count",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The number of HTTP response codes with numbers 300 to 399 generated by the applications in these tasks. These tasks are the targets. This metric only counts the responses sent to the Service Connect proxies by the applications in these tasks, not responses sent directly. This metric is only available if you have configured Amazon ECS Service Connect and the `appProtocol` is `HTTP` or `HTTP2` in the port mapping in the task definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Average, Minimum, Maximum, Sum"
+  },
+  {
+    "metricId": {
+      "metricName": "HTTPCode_Target_4XX_Count",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The number of HTTP response codes with numbers 400 to 499 generated by the applications in these tasks. These tasks are the targets. This metric only counts the responses sent to the Service Connect proxies by the applications in these tasks, not responses sent directly. This metric is only available if you have configured Amazon ECS Service Connect and the `appProtocol` is `HTTP` or `HTTP2` in the port mapping in the task definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Average, Minimum, Maximum, Sum"
+  },
+  {
+    "metricId": {
+      "metricName": "HTTPCode_Target_5XX_Count",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The number of HTTP response codes with numbers 500 to 599 generated by the applications in these tasks. These tasks are the targets. This metric only counts the responses sent to the Service Connect proxies by the applications in these tasks, not responses sent directly. This metric is only available if you have configured Amazon ECS Service Connect and the `appProtocol` is `HTTP` or `HTTP2` in the port mapping in the task definition.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Average, Minimum, Maximum, Sum",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect a high server-side error count for the ECS service. This can indicate that there are errors that cause the server to be unable to serve requests. To troubleshoot, check your application logs.",
+        "threshold": {
+          "justification": "Calculate the value of about 5% of the your average traffic and use this value as a starting point for the threshold. You can find the average traffic by using the `RequestCount` metric. You can also analyze historical data to determine the acceptable error rate for the application workload, and then tune the threshold accordingly. Frequently occurring 5XX errors need to be alarmed on. However, setting a very low value for the threshold can cause the alarm to be too sensitive."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "notBreaching",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "ServiceName"
+          }
+        ],
+        "intent": "This alarm is used to detect a high server-side error count for the ECS service."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "RequestCountPerTarget",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The average number of requests received by each target that share the selected `DiscoveryName`. This metric is only available if you have configured Amazon ECS Service Connect.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Average"
+  },
+  {
+    "metricId": {
+      "metricName": "TargetProcessedBytes",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The total number of bytes processed by the Service Connect proxies. This metric is only available if you have configured Amazon ECS Service Connect.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Average, Minimum, Maximum, Sum"
+  },
+  {
+    "metricId": {
+      "metricName": "TargetResponseTime",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The latency of the application request processing. The time elapsed, in milliseconds, after the request reached the Service Connect proxy in the target task until a response from the target application is received back to the proxy. This metric is only available if you have configured Amazon ECS Service Connect.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Average, Minimum, Maximum",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect a high target response time for ECS service requests. This can indicate that there are problems that cause the service to be unable to serve requests in time. To troubleshoot, check the CPUUtilization metric to see if the service is running out of CPU, or check the CPU utilization of other downstream services that your service depends on.",
+        "threshold": {
+          "justification": "The recommended threshold value for this alarm is highly dependent on your use case. Review the criticality and requirements of the target response time of the service and analyze the historical behavior of this metric to determine sensible threshold levels."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "ServiceName"
+          }
+        ],
+        "intent": "This alarm is used to detect a high target response time for ECS service requests."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "EBSFilesystemUtilization",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The percentage of the Amazon EBS filesystem that is used by tasks in a service. The service level EBS filesystem utilization metric (filtered by `ClusterName`, `ServiceName`) is measured as the total amount of the EBS filesystem in use by the tasks that belong to the service, divided by the total amount of EBS filesystem storage that is allocated for all tasks that belong to the service. The service level EBS filesystem utilization metric is only available for tasks hosted on Amazon EC2 instances (using container agent version `1.79.0` ) and Fargate (using platform version `1.4.0`) that have an EBS volume attached. Note: For tasks hosted on Fargate, there is space on the disk that is only used by Fargate. There is no cost associated with the space Fargate uses, but you will see this additional storage using tools like `df`.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Average, Minimum, Maximum",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect high storage utilization of the EBS volume attached to Amazon ECS tasks. If the utilization of the EBS volume is consistently high, you can check the usage and increase the volume size for new tasks.",
+        "threshold": {
+          "staticValue": 90.0,
+          "justification": "You can set the threshold for EBS file system utilization to about 90%. You can adjust this value based on the acceptable storage utilization. For a read only snapshot volume, a high utilization might indicate that the volume is right sized. For an active data volume, high storage utilization might indicate that the application is writing a large amount of data which might cause the container to fail if there is not enough capacity."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "ClusterName"
+          },
+          {
+            "name": "ServiceName"
+          }
+        ],
+        "intent": "This alarm is used to detect high storage utilization of the EBS volumes attached to Amazon ECS tasks. Consistently high storage utilization can indicate that the EBS volume is full and it might lead to failure of the container."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ClientTLSNegotiationErrorCount",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The total number of times the TLS connection failed. This metric is only used when TLS is enabled. This metric is only available if you have configured Amazon ECS Service Connect.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Average, Minimum, Maximum, Sum"
+  },
+  {
+    "metricId": {
+      "metricName": "TargetTLSNegotiationErrorCount",
+      "namespace": "AWS/ECS"
+    },
+    "description": "The total number of times the TLS connection failed due to missing client certificates, failed AWS Private CA verifications, or failed SAN verifications. This metric is only used when TLS is enabled. This metric is only available if you have configured Amazon ECS Service Connect.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Average, Minimum, Maximum, Sum"
+  },
+  {
+    "metricId": {
+      "metricName": "ActiveConnections",
+      "namespace": "AWS/PrivateLinkServices"
+    },
+    "description": "The maximum number of active connections from clients to targets through the endpoints. Increasing values could indicate the need to add targets to the load balancer. Reporting criteria: An endpoint connected to the endpoint service sent traffic during the one-minute period.",
+    "recommendedStatistics": "Average and Maximum.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesProcessed",
+      "namespace": "AWS/PrivateLinkServices"
+    },
+    "description": "The number of bytes exchanged between endpoint services and endpoints, in both directions. Reporting criteria: An endpoint connected to the endpoint service sent traffic during the one-minute period.",
+    "recommendedStatistics": "Average, Sum, and Maximum.",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "EndpointsCount",
+      "namespace": "AWS/PrivateLinkServices"
+    },
+    "description": "The number of endpoints connected to the endpoint service. Reporting criteria: There is a nonzero value during the five-minute period.",
+    "recommendedStatistics": "Average and Maximum.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NewConnections",
+      "namespace": "AWS/PrivateLinkServices"
+    },
+    "description": "The number of new connections established from clients to targets through the endpoints. Increasing values could indicate the need to add targets to the load balancer. Reporting criteria: An endpoint connected to the endpoint service sent traffic during the one-minute period.",
+    "recommendedStatistics": "Average, Sum, and Maximum.",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "RstPacketsSent",
+      "namespace": "AWS/PrivateLinkServices"
+    },
+    "description": "The number of RST packets sent to endpoints by the endpoint service. Increasing values could indicate that there are unhealthy targets. Reporting criteria: An endpoint connected to the endpoint service sent traffic during the one-minute period.",
+    "recommendedStatistics": "Average, Sum, and Maximum.",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you detect unhealthy targets of an endpoint service based on the number of reset packets that are sent to endpoints. When you debug connection errors with a consumer of your service, you can validate whether the service is resetting connections with the RstPacketsSent metric, or if something else is failing on the network path.",
+        "threshold": {
+          "justification": "The threshold depends on the use case. If your use case can tolerate targets being unhealthy, you can set the threshold high. If the use case can’t tolerate unhealthy targets you can set the threshold very low."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "Service Id"
+          },
+          {
+            "name": "Load Balancer Arn"
+          },
+          {
+            "name": "Az"
+          }
+        ],
+        "intent": "This alarm is used to detect unhealthy targets of an endpoint service."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ChildHealthCheckHealthyCount",
+      "namespace": "AWS/Route53"
+    },
+    "description": "For a calculated health check, the number of health checks that are healthy.",
+    "recommendedStatistics": "Average (recommended), Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ConnectionTime",
+      "namespace": "AWS/Route53"
+    },
+    "description": "The average time, in milliseconds, that it took Route 53 health checkers to establish a TCP connection with the endpoint. You can view `ConnectionTime` for a health check either across all regions or for a selected geographic region.",
+    "recommendedStatistics": "Average (recommended), Minimum, Maximum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "HealthCheckPercentageHealthy",
+      "namespace": "AWS/Route53"
+    },
+    "description": "The percentage of Route 53 health checkers that consider the selected endpoint to be healthy.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "HealthCheckStatus",
+      "namespace": "AWS/Route53"
+    },
+    "description": "The status of the health check endpoint that CloudWatch is checking. 1 indicates healthy, and 0 indicates unhealthy.",
+    "recommendedStatistics": "Minimum, Average, and Maximum",
+    "unitInfo": "none",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect unhealthy endpoints as per health checkers. To understand the reason for a failure that results in unhealthy status, use the Health Checkers tab in the Route 53 Health Check Console to view the status from each Region as well as the last failure of the health check. The status tab also displays the reason that the endpoint is reported as unhealthy. Refer to [troubleshooting steps](https://repost.aws/knowledge-center/route-53-fix-unhealthy-health-checks).",
+        "threshold": {
+          "staticValue": 1.0,
+          "justification": "The status of the endpoint is reported as 1 when it's healthy. Everything less than 1 is unhealthy."
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "breaching",
+        "dimensions": [
+          {
+            "name": "HealthCheckId"
+          }
+        ],
+        "intent": "This alarm uses Route53 health checkers to detect unhealthy endpoints."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "SSLHandshakeTime",
+      "namespace": "AWS/Route53"
+    },
+    "description": "The average time, in milliseconds, that it took Route 53 health checkers to complete the SSL handshake. You can view `SSLHandshakeTime` for a health check either across all regions or for a selected geographic region.",
+    "recommendedStatistics": "Average (recommended), Minimum, Maximum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "TimeToFirstByte",
+      "namespace": "AWS/Route53"
+    },
+    "description": "The average time, in milliseconds, that it took Route 53 health checkers to receive the first byte of the response to an HTTP or HTTPS request. You can view `TimeToFirstByte` for a health check either across all regions or for a selected geographic region.",
+    "recommendedStatistics": "Average (recommended), Minimum, Maximum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "DNSQueries",
+      "namespace": "AWS/Route53"
+    },
+    "description": "For a hosted zone, the number of DNS queries that Route 53 responds to in a specified time period. Region: Route 53 is a global service. To get hosted zone metrics, you must specify US East (N. Virginia) for the Region.",
+    "recommendedStatistics": "Sum, SampleCount",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DNSSECInternalFailure",
+      "namespace": "AWS/Route53"
+    },
+    "description": "Value is 1 if any object in the hosted zone is in an INTERNAL_FAILURE state. Otherwise, value is 0. Volume: 1 per 4 hours per hosted zone. Region: Route 53 is a global service. To get hosted zone metrics, you must specify US East (N. Virginia) for the Region.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DNSSECKeySigningKeysNeedingAction",
+      "namespace": "AWS/Route53"
+    },
+    "description": "Number of key signing keys (KSKs) that have an ACTION_NEEDED state (due to KMS failure). Volume: 1 per 4 hours per hosted zone. Region: Route 53 is a global service. To get hosted zone metrics, you must specify US East (N. Virginia) for the Region.",
+    "recommendedStatistics": "Sum, SampleCount",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DNSSECKeySigningKeyMaxNeedingActionAge",
+      "namespace": "AWS/Route53"
+    },
+    "description": "Time elapsed since the key signing key (KSK) was set to the ACTION_NEEDED state. Volume: 1 per 4 hours per hosted zone. Region: Route 53 is a global service. To get hosted zone metrics, you must specify US East (N. Virginia) for the Region.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "DNSSECKeySigningKeyAge",
+      "namespace": "AWS/Route53"
+    },
+    "description": "The time elapsed since the key signing key (KSK) was created (not since it was activated). Volume: 1 per 4 hours per hosted zone. Region: Route 53 is a global service. To get hosted zone metrics, you must specify US East (N. Virginia) for the Region.",
+    "recommendedStatistics": "Maximum",
+    "unitInfo": "Seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "4xxErrorRate",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The percentage of all viewer requests for which the response's HTTP status code is `4xx`.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "401ErrorRate",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The percentage of all viewer requests for which the response's HTTP status code is `401`. To get this metric, you must first [turn on additional metrics](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional).",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "403ErrorRate",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The percentage of all viewer requests for which the response's HTTP status code is `403`. To get this metric, you must first [turn on additional metrics](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional).",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "404ErrorRate",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The percentage of all viewer requests for which the response's HTTP status code is `404`. To get this metric, you must first [turn on additional metrics](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional).",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "5xxErrorRate",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The percentage of all viewer requests for which the response's HTTP status code is `5xx`.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm monitors the percentage of 5xx error responses from your origin server, to help you detect if the CloudFront service is having issues. See [Troubleshooting error responses from your origin](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/troubleshooting-response-errors.html) for information to help you understand the problems with your server. Also, [turn on additional metrics](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional) to get detailed error metrics.",
+        "threshold": {
+          "justification": "The recommended threshold value for this alarm is highly dependent on the tolerance for 5xx responses. You can analyze historical data and trends, and then set the threshold accordingly. Because 5xx errors can be caused by transient issues, we recommend that you set the threshold to a value greater than 0 so that the alarm is not too sensitive."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DistributionId"
+          },
+          {
+            "name": "Region",
+            "value": "Global"
+          }
+        ],
+        "intent": "This alarm is used to detect problems with serving requests from the origin server, or problems with communication between CloudFront and your origin server."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "502ErrorRate",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The percentage of all viewer requests for which the response's HTTP status code is `502`. To get this metric, you must first [turn on additional metrics](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional).",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "503ErrorRate",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The percentage of all viewer requests for which the response's HTTP status code is `503`. To get this metric, you must first [turn on additional metrics](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional).",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "504ErrorRate",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The percentage of all viewer requests for which the response's HTTP status code is `504`. To get this metric, you must first [turn on additional metrics](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional).",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesDownloaded",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The total number of bytes downloaded by viewers for `GET`, `HEAD`, and `OPTIONS` requests.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "BytesUploaded",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The total number of bytes that viewers uploaded to your origin with CloudFront, using `POST` and `PUT` requests.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "CacheHitRate",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The percentage of all cacheable requests for which CloudFront served the content from its cache. HTTP `POST` and `PUT` requests, and errors, are not considered cacheable requests. To get this metric, you must first [turn on additional metrics](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional).",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "OriginLatency",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The total time spent, in milliseconds, from when CloudFront receives a request to when it starts providing a response to the network (not the viewer), for requests that are served from the origin, not the CloudFront cache. This is also known as first byte latency, or time-to-first-byte. To get this metric, you must first [turn on additional metrics](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional). Note: To get a `Percentile` statistic from the CloudWatch API, use the `ExtendedStatistics` parameter, not `Statistics`. For more information, see [GetMetricStatistics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricStatistics.html) in the Amazon CloudWatch API Reference, or the reference documentation for the [AWS SDKs](https://docs.aws.amazon.com/#sdks).",
+    "recommendedStatistics": "Percentile",
+    "unitInfo": "Milliseconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "The alarm helps to monitor if the origin server is taking too long to respond. If the server takes too long to respond, it might lead to a timeout. Refer to [find and fix delayed responses from applications on your origin server](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/http-504-gateway-timeout.html#http-504-gateway-timeout-slow-application) if you experience consistently high `OriginLatency` values.",
+        "threshold": {
+          "justification": "You should calculate the value of about 80% of the origin response timeout, and use the result as the threshold value. If this metric is consistently close to the origin response timeout value, you might start experiencing 504 errors."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "p90",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DistributionId"
+          },
+          {
+            "name": "Region",
+            "value": "Global"
+          }
+        ],
+        "intent": "This alarm is used to detect problems with the origin server taking too long to respond."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "Requests",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The total number of viewer requests received by CloudFront, for all HTTP methods and for both HTTP and HTTPS requests.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "TotalErrorRate",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The percentage of all viewer requests for which the response's HTTP status code is `4xx` or `5xx`.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "FunctionInvocations",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The number of times the function was started (invoked) in a given time period.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "FunctionValidationErrors",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The number of validation errors produced by the function in a given time period. Validation errors occur when the function runs successfully but returns invalid data (an invalid event object).",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you monitor validation errors from CloudFront functions so that you can take steps to resolve them. Analyze the CloudWatch function logs and look at the function code to find and resolve the root cause of the problem. See [restrictions on edge functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions-restrictions.html) to understand the common misconfigurations for CloudFront Functions.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "A value greater than 0 indicates a validation error. We recommend setting the threshold to 0 because validation errors imply a problem when CloudFront functions hand off back to CloudFront. For example, CloudFront needs the HTTP Host header in order to process a request. There is nothing stopping a user from deleting the Host header in their CloudFront functions code. But when CloudFront gets the response back and the Host header is missing, CloudFront throws a validation error."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 2,
+        "datapointsToAlarm": 2,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DistributionId"
+          },
+          {
+            "name": "FunctionName"
+          },
+          {
+            "name": "Region",
+            "value": "Global"
+          }
+        ],
+        "intent": "This alarm is used to detect validation errors from CloudFront functions."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "FunctionExecutionErrors",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The number of execution errors that occurred in a given time period. Execution errors occur when the function fails to complete successfully.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you monitor execution errors from CloudFront functions so that you can take steps to resolve them. Analyze the CloudWatch function logs and look at the function code to find and resolve the root cause of the problem.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "We recommend to set the threshold to 0 because an execution error indicates a problem with the code that occurs at runtime."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DistributionId"
+          },
+          {
+            "name": "FunctionName"
+          },
+          {
+            "name": "Region",
+            "value": "Global"
+          }
+        ],
+        "intent": "This alarm is used to detect execution errors from CloudFront functions."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "FunctionComputeUtilization",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The amount of time (0-100) that the function took to run as a percentage of the maximum allowed time. For example, a value of 35 means that the function completed in 35% of the maximum allowed time.",
+    "recommendedStatistics": "Average",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "FunctionThrottles",
+      "namespace": "AWS/CloudFront"
+    },
+    "description": "The number of times that the function was throttled in a given time period.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "None",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you to monitor if your CloudFront function is throttled. If your function is throttled, it means that it is taking too long to execute. To avoid function throttles, consider optimizing the function code.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "We recommend setting the threshold to 0, to allow quicker resolution of the function throttles."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 5,
+        "datapointsToAlarm": 5,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "DistributionId"
+          },
+          {
+            "name": "FunctionName"
+          },
+          {
+            "name": "Region",
+            "value": "Global"
+          }
+        ],
+        "intent": "This alarm can detect when your CloudFront function is throttled so that you can react and resolve the issue for a smooth customer experience."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ApproximateAgeOfOldestMessage",
+      "namespace": "AWS/SQS"
+    },
+    "description": "The approximate age of the oldest non-deleted message in the queue. Reporting criteria: A non-negative value is reported [if the queue is active](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/monitoring-using-cloudwatch.html). Note: After a message is received three times (or more) and not processed, the message is moved to the back of the queue and the `ApproximateAgeOfOldestMessage` metric points to the second-oldest message that hasn't been received more than three times. This action occurs even if the queue has a redrive policy. Because a single \"poison-pill\" message (received multiple times but never deleted) can distort this metric, the age of such a message isn't included until it is consumed successfully. When the queue has a redrive policy, the message is moved to a [dead-letter queue (DLQ)](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html) after the configured maximum number of receives. When the message is moved to the DLQ, the `ApproximateAgeOfOldestMessage` metric of the DLQ represents the time when the message was moved to the DLQ, not the original time the message was sent. For FIFO queues, the message is not moved to the back of the queue because this will break the FIFO order guarantee. Instead, the message goes to the DLQ if one is configured; otherwise, it will block the message group until successfully deleted or until it expires.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum, Data Samples (displays as Sample Count in the Amazon SQS console)",
+    "unitInfo": "Seconds",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm watches the age of the oldest message in the queue. You can use this alarm to monitor if your consumers are processing SQS messages at the desired speed. Consider increasing the consumer count or consumer throughput to reduce message age. This metric can be used in combination with `ApproximateNumberOfMessagesVisible` to determine how big the queue backlog is and how quickly messages are being processed. To prevent messages from being deleted before processed, consider configuring the dead-letter queue to sideline potential poison pill messages.",
+        "threshold": {
+          "justification": "The recommended threshold value for this alarm is highly dependent on the expected message processing time. You can use historical data to calculate the average message processing time, and then set the threshold to 50% higher than the maximum expected SQS message processing time by queue consumers."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "QueueName"
+          }
+        ],
+        "intent": "This alarm is used to detect whether the age of the oldest message in the QueueName queue is too high. High age can be an indication that messages are not processed quickly enough or that there are some poison-pill messages that are stuck in the queue and can't be processed. "
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ApproximateNumberOfMessagesDelayed",
+      "namespace": "AWS/SQS"
+    },
+    "description": "The number of messages in the queue that are delayed and not available for reading immediately. This can happen when the queue is configured as a delay queue or when a message has been sent with a delay parameter. Reporting criteria: A non-negative value is reported [if the queue is active](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/monitoring-using-cloudwatch.html).",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum, Data Samples (displays as Sample Count in the Amazon SQS console)",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "ApproximateNumberOfMessagesNotVisible",
+      "namespace": "AWS/SQS"
+    },
+    "description": "The number of messages that are in flight. Messages are considered to be in flight if they have been sent to a client but have not yet been deleted or have not yet reached the end of their visibility window. Reporting criteria: A non-negative value is reported [if the queue is active](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/monitoring-using-cloudwatch.html).",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum, Data Samples (displays as Sample Count in the Amazon SQS console)",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect a high number of in-flight messages with respect to `QueueName`. For troubleshooting, check [message backlog decreasing](https://repost.aws/knowledge-center/sqs-message-backlog).",
+        "threshold": {
+          "justification": "The recommended threshold value for this alarm is highly dependent on the expected number of messages in flight. You can use historical data to calculate the maximum expected number of messages in flight and set the threshold to 50% over this value. If consumers of the queue are processing but not deleting messages from the queue, this number will suddenly increase."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "QueueName"
+          }
+        ],
+        "intent": "This alarm is used to detect a high number of in-flight messages in the queue. If consumers do not delete messages within the visibility timeout period, when the queue is polled, messages reappear in the queue. For FIFO queues, there can be a maximum of 20,000 in-flight messages. If you reach this quota, SQS returns no error messages. A FIFO queue looks through the first 20k messages to determine available message groups. This means that if you have a backlog of messages in a single message group, you cannot consume messages from other message groups that were sent to the queue at a later time until you successfully consume the messages from the backlog."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "ApproximateNumberOfMessagesVisible",
+      "namespace": "AWS/SQS"
+    },
+    "description": "The number of messages to be processed. Reporting criteria: A non-negative value is reported [if the queue is active](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/monitoring-using-cloudwatch.html). There is no limit on the number of messages to processes, however you can subject this backlog to a retention period.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum, Data Samples (displays as Sample Count in the Amazon SQS console)",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm watches for the message queue backlog to be bigger than expected, indicating that consumers are too slow or there are not enough consumers. Consider increasing the consumer count or speeding up consumers, if this alarm goes into ALARM state.",
+        "threshold": {
+          "justification": "An unexpectedly high number of messages visible indicates that messages are not being processed by a consumer at the expected rate. You should consider historical data when you set this threshold."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "QueueName"
+          }
+        ],
+        "intent": "This alarm is used to detect whether the message count of the active queue is too high and consumers are slow to process the messages or there are not enough consumers to process them."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfEmptyReceives",
+      "namespace": "AWS/SQS"
+    },
+    "description": "The number of `ReceiveMessage` API calls that did not return a message. Reporting criteria: A non-negative value is reported [if the queue is active](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/monitoring-using-cloudwatch.html).",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum, Data Samples (displays as Sample Count in the Amazon SQS console)",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfMessagesDeleted",
+      "namespace": "AWS/SQS"
+    },
+    "description": "The number of messages deleted from the queue. Reporting criteria: A non-negative value is reported [if the queue is active](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/monitoring-using-cloudwatch.html). Amazon SQS emits the `NumberOfMessagesDeleted` metric for every successful deletion operation that uses a valid [receipt handle](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-message-identifiers.html#receipt-handle), including duplicate deletions. The following scenarios might cause the value of the `NumberOfMessagesDeleted` metric to be higher than expected: Calling the `DeleteMessage` action on different receipt handles that belong to the same message: If the message is not processed before the [visibility timeout](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html) expires, the message becomes available to other consumers that can process it and delete it again, increasing the value of the `NumberOfMessagesDeleted` metric. Calling the `DeleteMessage` action on the same receipt handle: If the message is processed and deleted but you call the `DeleteMessage` action again using the same receipt handle, a success status is returned, increasing the value of the `NumberOfMessagesDeleted` metric.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum, Data Samples (displays as Sample Count in the Amazon SQS console)",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfMessagesReceived",
+      "namespace": "AWS/SQS"
+    },
+    "description": "The number of messages returned by calls to the `ReceiveMessage` action. Reporting criteria: A non-negative value is reported [if the queue is active](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/monitoring-using-cloudwatch.html).",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum, Data Samples (displays as Sample Count in the Amazon SQS console)",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfMessagesSent",
+      "namespace": "AWS/SQS"
+    },
+    "description": "The number of messages added to a queue. If you send a message to a DLQ manually, it is captured by the `NumberOfMessagesSent` metric. However, if a message is sent to a DLQ as a result of a failed processing attempt (for example, automatically moved due to exceeding the `maxReceiveCount`), it is not captured by this metric. Therefore, it is possible for the values of `NumberOfMessagesSent` and `NumberOfMessagesReceived` to differ. Reporting criteria: A non-negative value is reported [if the queue is active](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/monitoring-using-cloudwatch.html).",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum, Data Samples (displays as Sample Count in the Amazon SQS console)",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to detect if there are no messages being sent from a producer with respect to `QueueName`. For troubleshooting, check the reason that the producer is not sending messages.",
+        "threshold": {
+          "staticValue": 0.0,
+          "justification": "If the number of messages sent is 0, the producer is not sending any messages. If this queue has a low TPS, increase the number of EvaluationPeriods accordingly. "
+        },
+        "period": 60,
+        "comparisonOperator": "LessThanOrEqualToThreshold",
+        "statistic": "Sum",
+        "evaluationPeriods": 15,
+        "datapointsToAlarm": 15,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "QueueName"
+          }
+        ],
+        "intent": "This alarm is used to detect when a producer stops sending messages."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "SentMessageSize",
+      "namespace": "AWS/SQS"
+    },
+    "description": "The size of messages added to a queue. Reporting criteria: A non-negative value is reported [if the queue is active](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/monitoring-using-cloudwatch.html). Note: `SentMessageSize` does not display as an available metric in the CloudWatch console until at least one message is sent to the corresponding queue.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum, Data Samples (displays as Sample Count in the Amazon SQS console)",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ApproximateNumberOfGroupsWithInflightMessages",
+      "namespace": "AWS/SQS"
+    },
+    "description": "The approximate number of message groups with in flight messages, where a message is considered to be in flight after it's received from a queue by a consumer, but not yet deleted from the queue. This metric can help you troubleshoot and optimize your FIFO queue throughput by either increasing FIFO message groups, or scaling your consumers. Reporting criteria: A non-negative value is reported [if the queue is active](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/monitoring-using-cloudwatch.html). For current FIFO throughput and in flight limits, see [Amazon SQS message quotas](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html).",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum, Data Samples (displays as Sample Count in the Amazon SQS console)",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NumberOfDeduplicatedSentMessages",
+      "namespace": "AWS/SQS"
+    },
+    "description": "The number of messages sent to a queue that were deduplicated. This metric can help determine if a producer is sending duplicate messages to an Amazon SQS FIFO queue. Reporting criteria: A non-negative value is reported [if the queue is active](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/monitoring-using-cloudwatch.html).",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum, Data Samples (displays as Sample Count in the Amazon SQS console)",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "QueriesCompletedPerSecond",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "The number of queries completed each second.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Number of queries"
+  },
+  {
+    "metricId": {
+      "metricName": "QueryDuration",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "The average amount of time to complete a query.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Percentiles, Trimmed Mean",
+    "unitInfo": "Microseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "QueriesRunning",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "The number of running queries at a point in time.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Number of queries"
+  },
+  {
+    "metricId": {
+      "metricName": "QueriesQueued",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "The number of queries in the queue at a point in time.",
+    "recommendedStatistics": "Average, Maximum, Minimum",
+    "unitInfo": "Number of queries"
+  },
+  {
+    "metricId": {
+      "metricName": "DatabaseConnections",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "The number of connections to a database at a point in time.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Number of connections"
+  },
+  {
+    "metricId": {
+      "metricName": "QueryRuntimeBreakdown",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "The total time queries ran, by query stage.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Milliseconds"
+  },
+  {
+    "metricId": {
+      "metricName": "ComputeCapacity",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "Average number of compute units allocated during the past 30 minutes, rounded up to the nearest integer.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "RPU"
+  },
+  {
+    "metricId": {
+      "metricName": "ComputeSeconds",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "Accumulated compute-unit seconds used in the last 30 minutes.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "RPU-seconds"
+  },
+  {
+    "metricId": {
+      "metricName": "QueriesSucceeded",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "The number of queries that succeeded in the last 5 minutes.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Number of queries"
+  },
+  {
+    "metricId": {
+      "metricName": "QueriesFailed",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "The number of queries that failed in the last 5 minutes.",
+    "recommendedStatistics": "Average, Minimum, Maximum, Sum",
+    "unitInfo": "Number of queries"
+  },
+  {
+    "metricId": {
+      "metricName": "UsageLimitAvailable",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "Depending on the UsageType, UsageLimitAvailable returns the following: If the UsageType is SERVERLESS_COMPUTE, UsageLimitAvailable returns the remaining number of RPU-hours that the workgroup can query in the given limit. If the UsageType is CROSS_REGION_DATASHARING, UsageLimitAvailable returns the remaining number of TBs that the customer can scan in the given limit.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "RPU-hours or TBs"
+  },
+  {
+    "metricId": {
+      "metricName": "UsageLimitConsumed",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "Depending on the UsageType, UsageLimitConsumed returns the following: If the UsageType is SERVERLESS_COMPUTE, UsageLimitConsumed returns the number of RPU-hours that the workgroup has already queried in the given limit. If the UsageType is CROSS_REGION_DATASHARING, UsageLimitConsumed returns the number of TBs that the customer has already used to scan in the given limit.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "RPU-hours or TBs"
+  },
+  {
+    "metricId": {
+      "metricName": "TotalTableCount",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "The number of user tables existing at a point in time. This total doesn't include Amazon Redshift Spectrum tables.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Number of tables"
+  },
+  {
+    "metricId": {
+      "metricName": "DataStorage",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "The number of megabytes used, in disk or storage space, for Redshift data.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Megabytes"
+  },
+  {
+    "metricId": {
+      "metricName": "SnapshotStorage",
+      "namespace": "AWS/Redshift-Serverless"
+    },
+    "description": "The number of megabytes used, in disk or storage space, for Snapshots.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Megabytes"
+  },
+  {
+    "metricId": {
+      "metricName": "ReadinessChecks",
+      "namespace": "AWS/Route53RecoveryReadiness"
+    },
+    "description": "Represents the number of readiness checks processed by ARC. Reporting criteria: There is a nonzero value.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count."
+  },
+  {
+    "metricId": {
+      "metricName": "Resources",
+      "namespace": "AWS/Route53RecoveryReadiness"
+    },
+    "description": "Represents the number of resources processed by ARC, which can be dimensioned by their resource identifier, as defined by the API. Reporting criteria: There is a nonzero value.",
+    "recommendedStatistics": "Sum",
+    "unitInfo": "Count."
+  },
+  {
+    "metricId": {
+      "metricName": "CapacityProviderReservation",
+      "namespace": "AWS/ECS/ManagedScaling"
+    },
+    "description": "The percent of container instances in use for a specific capacity provider. Amazon ECS generates this metric. Amazon ECS sets the `CapacityProviderReservation` value to a number between 0-100. Amazon ECS uses the following formula to represent the ratio of how much capacity remains in the Auto Scaling group. Then, Amazon ECS publishes the metric to CloudWatch. For more information about how the metric is calculated, see [Deep Dive on Amazon ECS Cluster Auto Scaling](https://aws.amazon.com/blogs/containers/deep-dive-on-amazon-ecs-cluster-auto-scaling/). `CapacityProviderReservation = (number of instances needed) / (number of running instances) x 100`",
+    "recommendedStatistics": "Average, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "DesiredCapacity",
+      "namespace": "AWS/ECS/ManagedScaling"
+    },
+    "description": "The amount of capacity for the Auto Scaling group. This metric isn't published to CloudWatch.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "None"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUUtilization",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The percentage of physical CPU time that Amazon EC2 uses to run the EC2 instance, which includes time spent to run both the user code and the Amazon EC2 code. At a very high level, `CPUUtilization` is the sum of guest `CPUUtilization` and hypervisor `CPUUtilization`. Tools in your operating system can show a different percentage than CloudWatch due to factors such as legacy device simulation, configuration of non-legacy devices, interrupt-heavy workloads, live migration, and live update.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Percent",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor the CPU utilization of an EC2 instance. Depending on the application, consistently high utilization levels might be normal. But if performance is degraded, and the application is not constrained by disk I/O, memory, or network resources, then a maxed-out CPU might indicate a resource bottleneck or application performance problems. High CPU utilization might indicate that an upgrade to a more CPU intensive instance is required. If detailed monitoring is enabled, you can change the period to 60 seconds instead of 300 seconds. For more information, see [Enable or turn off detailed monitoring for your instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html).",
+        "threshold": {
+          "staticValue": 80.0,
+          "justification": "Typically, you can set the threshold for CPU utilization to 70-80%. However, you can adjust this value based on your acceptable performance level and workload characteristics. For some systems, consistently high CPU utilization may be normal and not indicate a problem, while for others, it may be cause of concern. Analyze historical CPU utilization data to identify the usage, find what CPU utilization is acceptable for your system, and set the threshold accordingly."
+        },
+        "period": 300,
+        "comparisonOperator": "GreaterThanThreshold",
+        "statistic": "Average",
+        "evaluationPeriods": 3,
+        "datapointsToAlarm": 3,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "InstanceId"
+          }
+        ],
+        "intent": "This alarm is used to detect high CPU utilization."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "DiskReadOps",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Completed read operations from all instance store volumes available to the instance in a specified period of time. To calculate the average I/O operations per second (IOPS) for the period, divide the total operations in the period by the number of seconds in that period. If there are no instance store volumes, either the value is 0 or the metric is not reported.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DiskWriteOps",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Completed write operations to all instance store volumes available to the instance in a specified period of time. To calculate the average I/O operations per second (IOPS) for the period, divide the total operations in the period by the number of seconds in that period. If there are no instance store volumes, either the value is 0 or the metric is not reported.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "DiskReadBytes",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Bytes read from all instance store volumes available to the instance. This metric is used to determine the volume of the data the application reads from the hard disk of the instance. This can be used to determine the speed of the application. The number reported is the number of bytes received during the period. If you are using basic (5-minute) monitoring, you can divide this number by 300 to find Bytes/second. If you have detailed (1-minute) monitoring, divide it by 60. You can also use the CloudWatch metric math function `DIFF_TIME` to find the bytes per second. For example, if you have graphed `DiskReadBytes` in CloudWatch as `m1`, the metric math formula `m1/(DIFF_TIME(m1))` returns the metric in bytes/second. For more information about `DIFF_TIME` and other metric math functions, see [Use metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) in the Amazon CloudWatch User Guide. If there are no instance store volumes, either the value is 0 or the metric is not reported.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "DiskWriteBytes",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Bytes written to all instance store volumes available to the instance. This metric is used to determine the volume of the data the application writes onto the hard disk of the instance. This can be used to determine the speed of the application. The number reported is the number of bytes received during the period. If you are using basic (5-minute) monitoring, you can divide this number by 300 to find Bytes/second. If you have detailed (1-minute) monitoring, divide it by 60. You can also use the CloudWatch metric math function `DIFF_TIME` to find the bytes per second. For example, if you have graphed `DiskWriteBytes` in CloudWatch as `m1`, the metric math formula `m1/(DIFF_TIME(m1))` returns the metric in bytes/second. For more information about `DIFF_TIME` and other metric math functions, see [Use metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) in the Amazon CloudWatch User Guide. If there are no instance store volumes, either the value is 0 or the metric is not reported.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "MetadataNoToken",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of times the Instance Metadata Service (IMDS) was successfully accessed using a method that does not use a token. This metric is used to determine if there are any processes accessing instance metadata that are using Instance Metadata Service Version 1 (IMDSv1), which does not use a token. If all requests use token-backed sessions, i.e., Instance Metadata Service Version 2 (IMDSv2), the value is 0. For more information, see [Transition to using Instance Metadata Service Version 2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-transition-to-version-2.html).",
+    "recommendedStatistics": "Sum, Percentiles",
+    "unitInfo": "Nitro instances: None, Xen instances: Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkIn",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of bytes received by the instance on all network interfaces. This metric identifies the volume of incoming network traffic to a single instance. The number reported is the number of bytes received during the period. If you are using basic (5-minute) monitoring and the statistic is Sum, you can divide this number by 300 to find Bytes/second. If you have detailed (1-minute) monitoring and the statistic is Sum, divide it by 60. You can also use the CloudWatch metric math function `DIFF_TIME` to find the bytes per second. For example, if you have graphed `NetworkIn` in CloudWatch as `m1`, the metric math formula `m1/(DIFF_TIME(m1))` returns the metric in bytes/second. For more information about `DIFF_TIME` and other metric math functions, see [Use metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) in the Amazon CloudWatch User Guide.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkOut",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of bytes sent out by the instance on all network interfaces. This metric identifies the volume of outgoing network traffic from a single instance. The number reported is the number of bytes sent during the period. If you are using basic (5-minute) monitoring and the statistic is Sum, you can divide this number by 300 to find Bytes/second. If you have detailed (1-minute) monitoring and the statistic is Sum, divide it by 60. You can also use the CloudWatch metric math function `DIFF_TIME` to find the bytes per second. For example, if you have graphed `NetworkOut` in CloudWatch as `m1`, the metric math formula `m1/(DIFF_TIME(m1))` returns the metric in bytes/second. For more information about `DIFF_TIME` and other metric math functions, see [Use metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) in the Amazon CloudWatch User Guide.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkPacketsIn",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of packets received by the instance on all network interfaces. This metric identifies the volume of incoming traffic in terms of the number of packets on a single instance. This metric is available for basic monitoring only (5-minute periods). To calculate the number of packets per second (PPS) your instance received for the 5 minutes, divide the Sum statistic value by 300. You can also use the CloudWatch metric math function `DIFF_TIME` to find the packets per second. For example, if you have graphed `NetworkPacketsIn` in CloudWatch as `m1`, the metric math formula `m1/(DIFF_TIME(m1))` returns the metric in packets/second. For more information about `DIFF_TIME` and other metric math functions, see [Use metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) in the Amazon CloudWatch User Guide.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkPacketsOut",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of packets sent out by the instance on all network interfaces. This metric identifies the volume of outgoing traffic in terms of the number of packets on a single instance. This metric is available for basic monitoring only (5-minute periods). To calculate the number of packets per second (PPS) your instance sent for the 5 minutes, divide the Sum statistic value by 300. You can also use the CloudWatch metric math function `DIFF_TIME` to find the packets per second. For example, if you have graphed `NetworkPacketsOut` in CloudWatch as `m1`, the metric math formula `m1/(DIFF_TIME(m1))` returns the metric in packets/second. For more information about `DIFF_TIME` and other metric math functions, see [Use metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) in the Amazon CloudWatch User Guide.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUCreditUsage",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of CPU credits spent by the instance for CPU utilization. One CPU credit equals one vCPU running at 100% utilization for one minute or an equivalent combination of vCPUs, utilization, and time (for example, one vCPU running at 50% utilization for two minutes or two vCPUs running at 25% utilization for two minutes). CPU credit metrics are available at a 5-minute frequency only. If you specify a period greater than five minutes, use the Sum statistic instead of the Average statistic.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Credits (vCPU-minutes)"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUCreditBalance",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of earned CPU credits that an instance has accrued since it was launched or started. For T2 Standard, the `CPUCreditBalance` also includes the number of launch credits that have been accrued. Credits are accrued in the credit balance after they are earned, and removed from the credit balance when they are spent. The credit balance has a maximum limit, determined by the instance size. After the limit is reached, any new credits that are earned are discarded. For T2 Standard, launch credits do not count towards the limit. The credits in the `CPUCreditBalance` are available for the instance to spend to burst beyond its baseline CPU utilization. When an instance is running, credits in the `CPUCreditBalance` do not expire. When a T3 or T3a instance stops, the `CPUCreditBalance` value persists for seven days. Thereafter, all accrued credits are lost. When a T2 instance stops, the `CPUCreditBalance` value does not persist, and all accrued credits are lost. CPU credit metrics are available at a 5-minute frequency only.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Credits (vCPU-minutes)"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUSurplusCreditBalance",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of surplus credits that have been spent by an `unlimited` instance when its `CPUCreditBalance` value is zero. The `CPUSurplusCreditBalance` value is paid down by earned CPU credits. If the number of surplus credits exceeds the maximum number of credits that the instance can earn in a 24-hour period, the spent surplus credits above the maximum incur an additional charge. CPU credit metrics are available at a 5-minute frequency only.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Credits (vCPU-minutes)"
+  },
+  {
+    "metricId": {
+      "metricName": "CPUSurplusCreditsCharged",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of spent surplus credits that are not paid down by earned CPU credits, and which thus incur an additional charge. Spent surplus credits are charged when any of the following occurs: The spent surplus credits exceed the maximum number of credits that the instance can earn in a 24-hour period. Spent surplus credits above the maximum are charged at the end of the hour. The instance is stopped or terminated. The instance is switched from `unlimited` to `standard`. CPU credit metrics are available at a 5-minute frequency only.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Credits (vCPU-minutes)"
+  },
+  {
+    "metricId": {
+      "metricName": "DedicatedHostCPUUtilization",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The percentage of allocated compute capacity that is currently in use by the instances running on the Dedicated Host.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "EBSReadOps",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Completed read operations from all Amazon EBS volumes attached to the instance in a specified period of time. To calculate the average read I/O operations per second (Read IOPS) for the period, divide the total operations in the period by the number of seconds in that period. If you are using basic (5-minute) monitoring, you can divide this number by 300 to calculate the Read IOPS. If you have detailed (1-minute) monitoring, divide it by 60. You can also use the CloudWatch metric math function `DIFF_TIME` to find the operations per second. For example, if you have graphed `EBSReadOps` in CloudWatch as `m1`, the metric math formula `m1/(DIFF_TIME(m1))` returns the metric in operations/second. For more information about `DIFF_TIME` and other metric math functions, see [Use metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) in the Amazon CloudWatch User Guide.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "EBSWriteOps",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Completed write operations to all EBS volumes attached to the instance in a specified period of time. To calculate the average write I/O operations per second (Write IOPS) for the period, divide the total operations in the period by the number of seconds in that period. If you are using basic (5-minute) monitoring, you can divide this number by 300 to calculate the Write IOPS. If you have detailed (1-minute) monitoring, divide it by 60. You can also use the CloudWatch metric math function `DIFF_TIME` to find the operations per second. For example, if you have graphed `EBSWriteOps` in CloudWatch as `m1`, the metric math formula `m1/(DIFF_TIME(m1))` returns the metric in operations/second. For more information about `DIFF_TIME` and other metric math functions, see [Use metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) in the Amazon CloudWatch User Guide.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "EBSReadBytes",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Bytes read from all EBS volumes attached to the instance in a specified period of time. The number reported is the number of bytes read during the period. If you are using basic (5-minute) monitoring, you can divide this number by 300 to find Read Bytes/second. If you have detailed (1-minute) monitoring, divide it by 60. You can also use the CloudWatch metric math function `DIFF_TIME` to find the bytes per second. For example, if you have graphed `EBSReadBytes` in CloudWatch as `m1`, the metric math formula `m1/(DIFF_TIME(m1))` returns the metric in bytes/second. For more information about `DIFF_TIME` and other metric math functions, see [Use metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) in the Amazon CloudWatch User Guide.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "EBSWriteBytes",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Bytes written to all EBS volumes attached to the instance in a specified period of time. The number reported is the number of bytes written during the period. If you are using basic (5-minute) monitoring, you can divide this number by 300 to find Write Bytes/second. If you have detailed (1-minute) monitoring, divide it by 60. You can also use the CloudWatch metric math function `DIFF_TIME` to find the bytes per second. For example, if you have graphed `EBSWriteBytes` in CloudWatch as `m1`, the metric math formula `m1/(DIFF_TIME(m1))` returns the metric in bytes/second. For more information about `DIFF_TIME` and other metric math functions, see [Use metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) in the Amazon CloudWatch User Guide.",
+    "recommendedStatistics": "Sum, Average, Minimum, Maximum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "EBSIOBalance%",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Provides information about the percentage of I/O credits remaining in the burst bucket. This metric is available for basic monitoring only. This metric is available only for some `*.4xlarge` instance sizes and smaller that burst to their maximum performance for only 30 minutes at least once every 24 hours. The Sum statistic is not applicable to this metric.",
+    "recommendedStatistics": "Minimum, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "EBSByteBalance%",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Provides information about the percentage of throughput credits remaining in the burst bucket. This metric is available for basic monitoring only. This metric is available only for some `*.4xlarge` instance sizes and smaller that burst to their maximum performance for only 30 minutes at least once every 24 hours. The Sum statistic is not applicable to this metric.",
+    "recommendedStatistics": "Minimum, Maximum",
+    "unitInfo": "Percent"
+  },
+  {
+    "metricId": {
+      "metricName": "StatusCheckFailed",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Reports whether the instance has passed all status checks in the last minute. This metric can be either `0` (passed) or `1` (failed). By default, this metric is available at a 1-minute frequency at no charge.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps to monitor both system status checks and instance status checks. If either type of status check fails, then this alarm should be in ALARM state.",
+        "threshold": {
+          "staticValue": 1.0,
+          "justification": "When a status check fails, the value of this metric is 1. The threshold is set so that whenever the status check fails, the alarm is in ALARM state."
+        },
+        "period": 300,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 2,
+        "datapointsToAlarm": 2,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "InstanceId"
+          }
+        ],
+        "intent": "This alarm is used to detect the underlying problems with instances, including both system status check failures and instance status check failures."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "StatusCheckFailed_Instance",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Reports whether the instance has passed the instance status check in the last minute. This metric can be either `0` (passed) or `1` (failed). By default, this metric is available at a 1-minute frequency at no charge.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "StatusCheckFailed_System",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Reports whether the instance has passed the system status check in the last minute. This metric can be either `0` (passed) or `1` (failed). By default, this metric is available at a 1-minute frequency at no charge.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkMirrorIn",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of bytes received on all network interfaces by the instance that are mirrored. The number reported is the number of bytes received during the period. If you are using basic (five-minute) monitoring, you can divide this number by 300 to find Bytes/second. If you have detailed (one-minute) monitoring, divide it by 60.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkMirrorOut",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of bytes sent out on all network interfaces by the instance that are mirrored. The number reported is the number of bytes sent during the period. If you are using basic (five-minute) monitoring, you can divide this number by 300 to find Bytes/second. If you have detailed (one-minute) monitoring, divide it by 60.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkPacketsMirrorIn",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of packets received on all network interfaces by the instance that are mirrored. This metric is available for basic monitoring only.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkPacketsMirrorOut",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of packets sent out on all network interfaces by the instance that are mirrored. This metric is available for basic monitoring only.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkSkipMirrorIn",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of bytes received, that meet the traffic mirror filter rules, that did not get mirrored because of production traffic taking priority.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkSkipMirrorOut",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of bytes sent out, that meet the traffic mirror filter rules, that did not get mirrored because of production traffic taking priority.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Bytes"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkPacketsSkipMirrorIn",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of packets received, that meet the traffic mirror filter rules, that did not get mirrored because of production traffic taking priority. This metric is available for basic monitoring only.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkPacketsSkipMirrorOut",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of packets sent out, that meet the traffic mirror filter rules, that did not get mirrored because of production traffic taking priority. This metric is available for basic monitoring only.",
+    "recommendedStatistics": "Average, Maximum, Minimum, Sum",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkAddressUsage",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The NAU count per VPC. Reporting criteria. Every 24 hours.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "NetworkAddressUsagePeered",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The NAU count for the VPC and all VPCs that it's peered with. Reporting criteria. Every 24 hours.",
+    "recommendedStatistics": "Maximum, Minimum, Average",
+    "unitInfo": "Count"
+  },
+  {
+    "metricId": {
+      "metricName": "StatusCheckFailed_AttachedEBS",
+      "namespace": "AWS/EC2"
+    },
+    "description": "Reports whether the instance has passed the attached EBS status check in the last minute. This metric can be either `0` (passed) or `1` (failed). By default, this metric is available at a 1-minute frequency at no charge.",
+    "recommendedStatistics": "Average, Minimum, Maximum",
+    "unitInfo": "Count",
+    "alarmRecommendations": [
+      {
+        "alarmDescription": "This alarm helps you monitor whether the Amazon EBS volumes attached to an instance are reachable and able to complete I/O operations. This status check detects underlying issues with the compute or Amazon EBS infrastructure such as the following: 1) Hardware or software issues on the storage subsystems underlying the EBS volumes, 2) Hardware issues on the physical host that impact reachability of the EBS volumes, 3) connectivity issues between the instance and EBS volumes. When the attached EBS status check fails, you can either wait for Amazon to resolve the issue, or you can take actions, such as replacing the affected volumes or stopping and restarting the instance.",
+        "threshold": {
+          "staticValue": 1.0,
+          "justification": "When a status check fails, the value of this metric is 1. The threshold is set so that whenever the status check fails, the alarm is in ALARM state."
+        },
+        "period": 60,
+        "comparisonOperator": "GreaterThanOrEqualToThreshold",
+        "statistic": "Maximum",
+        "evaluationPeriods": 10,
+        "datapointsToAlarm": 10,
+        "treatMissingData": "missing",
+        "dimensions": [
+          {
+            "name": "InstanceId"
+          }
+        ],
+        "intent": "This alarm is used to detect unreachable Amazon EBS volumes attached to an instance. These can cause failures in I/O operations."
+      }
+    ]
+  },
+  {
+    "metricId": {
+      "metricName": "MetadataNoTokenRejected",
+      "namespace": "AWS/EC2"
+    },
+    "description": "The number of times an IMDSv1 call was attempted after IMDSv1 was disabled. If this metric appears, it indicates that an IMDSv1 call was attempted and rejected. You can either re-enable IMDSv1 or make sure all of your calls use IMDSv2. For more information, see [Transition to using Instance Metadata Service Version 2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-transition-to-version-2.html).",
+    "recommendedStatistics": "Sum, Percentiles",
+    "unitInfo": "Nitro instances: None, Xen instances: Count"
+  }
+]

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_metrics/models.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_metrics/models.py
@@ -48,3 +48,63 @@ class GetMetricDataResponse(BaseModel):
     
     metricDataResults: List[MetricDataResult] = Field(default_factory=list, description="The results of the metric data queries")
     messages: List[Dict[str, Any]] = Field(default_factory=list, description="Messages related to the GetMetricData operation")
+
+class MetricMetadataIndexKey:
+    """Key class for indexing metric metadata."""
+    
+    def __init__(self, namespace: str, metric_name: str):
+        self.namespace = namespace
+        self.metric_name = metric_name
+    
+    def __hash__(self) -> int:
+        """Generate hash for use as dictionary key."""
+        return hash((self.namespace, self.metric_name))
+    
+    def __eq__(self, other) -> bool:
+        """Check equality for dictionary key comparison."""
+        if not isinstance(other, MetricMetadataIndexKey):
+            return False
+        return (
+            self.namespace == other.namespace and
+            self.metric_name == other.metric_name
+        )
+    
+    def __repr__(self) -> str:
+        """String representation for debugging."""
+        return f"MetricMetadataIndexKey(namespace='{self.namespace}', metric_name='{self.metric_name}')"
+
+
+class MetricMetadata(BaseModel):
+    """Represents the metadata of a CloudWatch metric including description, unit and recommended statistics."""
+    
+    description: str = Field(..., description="Description of the metric")
+    recommendedStatistics: str = Field(..., description="Recommended statistics for the metric (e.g., 'Average, Maximum')")
+    unit: str = Field(..., description="Unit of measurement for the metric")
+
+class AlarmRecommendationThreshold(BaseModel):
+    """Represents an alarm threshold configuration."""
+    
+    staticValue: float = Field(..., description="The static threshold value")
+    justification: str = Field(..., description="Justification for the threshold value")
+
+
+class AlarmRecommendationDimension(BaseModel):
+    """Represents a dimension for alarm recommendations."""
+    
+    name: str = Field(..., description="The name of the dimension")
+    value: Optional[str] = Field(None, description="The value of the dimension (if specified)")
+
+
+class AlarmRecommendation(BaseModel):
+    """Represents a CloudWatch alarm recommendation."""
+    
+    alarmDescription: str = Field(..., description="Description of what the alarm monitors")
+    threshold: AlarmRecommendationThreshold = Field(..., description="Threshold configuration for the alarm")
+    period: int = Field(..., description="The period in seconds over which the statistic is applied")
+    comparisonOperator: str = Field(..., description="The arithmetic operation to use when comparing the statistic and threshold")
+    statistic: str = Field(..., description="The statistic to apply to the alarm's associated metric")
+    evaluationPeriods: int = Field(..., description="The number of periods over which data is compared to the threshold")
+    datapointsToAlarm: int = Field(..., description="The number of datapoints that must be breaching to trigger the alarm")
+    treatMissingData: str = Field(..., description="How to treat missing data points")
+    dimensions: List[AlarmRecommendationDimension] = Field(default_factory=list, description="List of dimensions for the alarm")
+    intent: str = Field(..., description="The intent or purpose of the alarm")

--- a/src/cloudwatch-mcp-server/tests/cloudwatch_metrics/test_metrics_models.py
+++ b/src/cloudwatch-mcp-server/tests/cloudwatch_metrics/test_metrics_models.py
@@ -20,6 +20,11 @@ from awslabs.cloudwatch_mcp_server.cloudwatch_metrics.models import (
     MetricDataPoint,
     MetricDataResult,
     GetMetricDataResponse,
+    MetricMetadataIndexKey,
+    MetricMetadata,
+    AlarmRecommendation,
+    AlarmRecommendationDimension,
+    AlarmRecommendationThreshold
 )
 from pydantic import ValidationError
 
@@ -162,3 +167,208 @@ class TestGetMetricDataResponse:
         assert len(response.metricDataResults) == 2
         assert response.metricDataResults[0].label == "CPUUtilization"
         assert response.metricDataResults[1].label == "MemoryUtilization"
+
+class TestMetricMetadataIndexKey:
+    """Tests for MetricMetadataIndexKey model."""
+
+    def test_key_creation(self):
+        """Test creating a metric metadata index key."""
+        key = MetricMetadataIndexKey("AWS/EC2", "CPUUtilization")
+        
+        assert key.namespace == "AWS/EC2"
+        assert key.metric_name == "CPUUtilization"
+
+    def test_key_hashing(self):
+        """Test that keys can be hashed for dictionary use."""
+        key1 = MetricMetadataIndexKey("AWS/EC2", "CPUUtilization")
+        key2 = MetricMetadataIndexKey("AWS/EC2", "CPUUtilization")
+        key3 = MetricMetadataIndexKey("AWS/Lambda", "Duration")
+        
+        # Same keys should have same hash
+        assert hash(key1) == hash(key2)
+        
+        # Different keys should have different hash (usually)
+        assert hash(key1) != hash(key3)
+
+    def test_key_equality(self):
+        """Test key equality comparison."""
+        key1 = MetricMetadataIndexKey("AWS/EC2", "CPUUtilization")
+        key2 = MetricMetadataIndexKey("AWS/EC2", "CPUUtilization")
+        key3 = MetricMetadataIndexKey("AWS/Lambda", "Duration")
+        
+        # Same keys should be equal
+        assert key1 == key2
+        
+        # Different keys should not be equal
+        assert key1 != key3
+        
+        # Key should not equal non-key objects
+        assert key1 != "not a key"
+
+    def test_key_as_dict_key(self):
+        """Test using key as dictionary key."""
+        key1 = MetricMetadataIndexKey("AWS/EC2", "CPUUtilization")
+        key2 = MetricMetadataIndexKey("AWS/EC2", "CPUUtilization")
+        key3 = MetricMetadataIndexKey("AWS/Lambda", "Duration")
+        
+        test_dict = {}
+        test_dict[key1] = "value1"
+        test_dict[key3] = "value2"
+        
+        # Should be able to retrieve using equivalent key
+        assert test_dict[key2] == "value1"
+        assert test_dict[key3] == "value2"
+        
+        # Should have 2 entries
+        assert len(test_dict) == 2
+
+    def test_key_repr(self):
+        """Test string representation of key."""
+        key = MetricMetadataIndexKey("AWS/EC2", "CPUUtilization")
+        repr_str = repr(key)
+        
+        assert "MetricMetadataIndexKey" in repr_str
+        assert "AWS/EC2" in repr_str
+        assert "CPUUtilization" in repr_str
+
+
+class TestMetricMetadata:
+    """Tests for MetricMetadata model."""
+
+    def test_metric_metadata_creation(self):
+        """Test creating a metric metadata with all fields."""
+        description = MetricMetadata(
+            description="Test metric description",
+            recommendedStatistics="Average, Maximum, Minimum",
+            unit="Percent"
+        )
+        
+        assert description.description == "Test metric description"
+        assert description.recommendedStatistics == "Average, Maximum, Minimum"
+        assert description.unit == "Percent"
+
+    def test_metric_metadata_validation(self):
+        """Test metric metadata field validation."""
+        # Test that all fields are required
+        try:
+            MetricMetadata()
+            assert False, "Should have raised validation error"
+        except Exception:
+            pass  # Expected
+        
+        try:
+            MetricMetadata(description="Test")
+            assert False, "Should have raised validation error"
+        except Exception:
+            pass  # Expected
+
+
+class TestDimension:
+    """Tests for Dimension model."""
+
+    def test_dimension_creation(self):
+        """Test creating a dimension."""
+        dimension = Dimension(name="InstanceId", value="i-1234567890abcdef0")
+        
+        assert dimension.name == "InstanceId"
+        assert dimension.value == "i-1234567890abcdef0"
+
+    def test_dimension_validation(self):
+        """Test dimension field validation."""
+        # Test that all fields are required
+        try:
+            Dimension()
+            assert False, "Should have raised validation error"
+        except Exception:
+            pass  # Expected
+
+
+class TestAlarmRecommendationThreshold:
+    """Tests for AlarmRecommendationThreshold model."""
+
+    def test_alarm_recommendation_threshold_creation(self):
+        """Test creating an alarm recommendation threshold."""
+        threshold = AlarmRecommendationThreshold(
+            staticValue=80.0,
+            justification="CPU usage should not exceed 80%"
+        )
+        
+        assert threshold.staticValue == 80.0
+        assert threshold.justification == "CPU usage should not exceed 80%"
+
+
+class TestAlarmRecommendationDimension:
+    """Tests for TestAlarmRecommendationDimension model."""
+
+    def test_alarm_recommendation_dimension_creation_with_value(self):
+        """Test creating an alarm recommendation dimension with value."""
+        dimension = AlarmRecommendationDimension(name="Role", value="WRITER")
+        
+        assert dimension.name == "Role"
+        assert dimension.value == "WRITER"
+
+    def test_alarm_recommendation_dimension_creation_without_value(self):
+        """Test creating an alarm recommendation dimension without value."""
+        dimension = AlarmRecommendationDimension(name="InstanceId")
+        
+        assert dimension.name == "InstanceId"
+        assert dimension.value is None
+
+
+class TestAlarmRecommendation:
+    """Tests for AlarmRecommendation model."""
+
+    def test_alarm_recommendation_creation(self):
+        """Test creating a complete alarm recommendation."""
+        threshold = AlarmRecommendationThreshold(
+            staticValue=80.0,
+            justification="Test justification"
+        )
+        
+        dimensions = [
+            AlarmRecommendationDimension(name="InstanceId"),
+            AlarmRecommendationDimension(name="Role", value="WRITER")
+        ]
+        
+        alarm = AlarmRecommendation(
+            alarmDescription="Test alarm description",
+            threshold=threshold,
+            period=300,
+            comparisonOperator="GreaterThanThreshold",
+            statistic="Average",
+            evaluationPeriods=2,
+            datapointsToAlarm=2,
+            treatMissingData="missing",
+            dimensions=dimensions,
+            intent="Test alarm intent"
+        )
+        
+        assert alarm.alarmDescription == "Test alarm description"
+        assert alarm.threshold.staticValue == 80.0
+        assert alarm.period == 300
+        assert alarm.comparisonOperator == "GreaterThanThreshold"
+        assert alarm.statistic == "Average"
+        assert alarm.evaluationPeriods == 2
+        assert alarm.datapointsToAlarm == 2
+        assert alarm.treatMissingData == "missing"
+        assert len(alarm.dimensions) == 2
+        assert alarm.intent == "Test alarm intent"
+
+    def test_alarm_recommendation_with_minimal_fields(self):
+        """Test creating alarm recommendation with minimal required fields."""
+        threshold = AlarmRecommendationThreshold(staticValue=1.0, justification="Test")
+        
+        alarm = AlarmRecommendation(
+            alarmDescription="Minimal alarm",
+            threshold=threshold,
+            period=60,
+            comparisonOperator="GreaterThanThreshold",
+            statistic="Maximum",
+            evaluationPeriods=1,
+            datapointsToAlarm=1,
+            treatMissingData="missing",
+            intent="Minimal test"
+        )
+        
+        assert alarm.alarmDescription == "Minimal alarm"
+        assert len(alarm.dimensions) == 0  # Default empty list


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

Added CloudWatch Metrics metadata and alarm recommendation capabilities to the CloudWatch MCP server. This enhancement introduces two new tools:

1. `get_metric_metadata`: Retrieves comprehensive metadata about CloudWatch metrics, including descriptions, units, and recommended statistics to use
2. `get_recommended_metric_alarms`: Fetches alarm recommendations for specific CloudWatch metrics with appropriate thresholds and settings

The implementation includes a metadata loading system that indexes information from a JSON file, providing quick access to metric documentation and alarm recommendations with dimension-based filtering.

### User experience

**Before:**
Users could access CloudWatch metric data through the MCP server but lacked critical context about metrics and had to manually determine appropriate alarm thresholds.

**After:**
Users can now:
- Access detailed documentation about metrics to better understand what they're measuring and how to interpret the values
- Retrieve AWS-recommended alarm configurations for metrics, including appropriate thresholds, comparison operators, and evaluation periods
- Filter alarm recommendations based on specific resource dimensions

This provides a more complete monitoring solution where users can not only access metric data but also understand metrics better and implement best-practice alarm configurations.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? N

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).