### PR TITLE
Adding initial support for Alarm tooling

### DIFF
--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_alarms/models.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_alarms/models.py
@@ -1,0 +1,114 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data models for CloudWatch Alarms MCP tools."""
+
+from pydantic import BaseModel, Field
+from typing import Optional, List, Dict
+from datetime import datetime
+
+
+class MetricAlarmSummary(BaseModel):
+    """Summary information for a CloudWatch metric alarm in ALARM state."""
+    
+    alarm_name: str = Field(..., description="Name of the alarm")
+    alarm_description: Optional[str] = Field(None, description="Description of the alarm")
+    state_value: str = Field(..., description="Current state of the alarm (ALARM)")
+    state_reason: str = Field(..., description="Reason for the current state")
+    metric_name: str = Field(..., description="Name of the metric being monitored")
+    namespace: str = Field(..., description="Namespace of the metric")
+    dimensions: List[Dict[str, str]] = Field(default_factory=list, description="Key dimensions for the metric")
+    threshold: float = Field(..., description="Threshold value for the alarm")
+    comparison_operator: str = Field(..., description="Comparison operator used")
+    state_updated_timestamp: datetime = Field(..., description="When the alarm state was last updated")
+    alarm_type: str = Field(default="MetricAlarm", description="Type of alarm")
+
+
+class CompositeAlarmSummary(BaseModel):
+    """Summary information for a CloudWatch composite alarm in ALARM state."""
+    
+    alarm_name: str = Field(..., description="Name of the composite alarm")
+    alarm_description: Optional[str] = Field(None, description="Description of the alarm")
+    state_value: str = Field(..., description="Current state of the alarm")
+    state_reason: str = Field(..., description="Reason for the current state")
+    alarm_rule: str = Field(..., description="Rule expression for the composite alarm")
+    state_updated_timestamp: datetime = Field(..., description="When the alarm state was last updated")
+    alarm_type: str = Field(default="CompositeAlarm", description="Type of alarm")
+
+
+class ActiveAlarmsResponse(BaseModel):
+    """Response containing active CloudWatch alarms."""
+    
+    metric_alarms: List[MetricAlarmSummary] = Field(default_factory=list, description="List of active metric alarms")
+    composite_alarms: List[CompositeAlarmSummary] = Field(default_factory=list, description="List of active composite alarms")
+    has_more_results: bool = Field(default=False, description="Whether more alarms are available than the requested max_items")
+    message: Optional[str] = Field(None, description="Informational message about the results")
+
+
+class AlarmHistoryItem(BaseModel):
+    """Represents a processed CloudWatch alarm history item."""
+    
+    alarm_name: str = Field(..., description="Name of the alarm")
+    alarm_type: str = Field(..., description="Type of alarm (MetricAlarm or CompositeAlarm)")
+    timestamp: datetime = Field(..., description="Timestamp of the history item")
+    history_item_type: str = Field(..., description="Type of history item (StateUpdate, ConfigurationUpdate, Action)")
+    history_summary: str = Field(..., description="Human-readable summary of the history item")
+    old_state: Optional[str] = Field(None, description="Previous state of the alarm (for StateUpdate items)")
+    new_state: Optional[str] = Field(None, description="New state of the alarm (for StateUpdate items)")
+    state_reason: Optional[str] = Field(None, description="Reason for the state change (for StateUpdate items)")
+
+
+class AlarmDetails(BaseModel):
+    """Represents key details about a CloudWatch alarm."""
+    
+    alarm_name: str = Field(..., description="Name of the alarm")
+    alarm_description: Optional[str] = Field(None, description="Description of the alarm")
+    alarm_type: str = Field(..., description="Type of alarm (MetricAlarm or CompositeAlarm)")
+    current_state: str = Field(..., description="Current state of the alarm")
+    metric_name: Optional[str] = Field(None, description="Name of the metric (for MetricAlarm)")
+    namespace: Optional[str] = Field(None, description="Namespace of the metric (for MetricAlarm)")
+    dimensions: List[Dict[str, str]] = Field(default_factory=list, description="Dimensions of the metric (for MetricAlarm)")
+    threshold: Optional[float] = Field(None, description="Threshold value (for MetricAlarm)")
+    comparison_operator: Optional[str] = Field(None, description="Comparison operator (for MetricAlarm)")
+    evaluation_periods: Optional[int] = Field(None, description="Number of evaluation periods (for MetricAlarm)")
+    period: Optional[int] = Field(None, description="Period in seconds (for MetricAlarm)")
+    statistic: Optional[str] = Field(None, description="Statistic used (for MetricAlarm)")
+    alarm_rule: Optional[str] = Field(None, description="Rule expression (for CompositeAlarm)")
+
+
+class TimeRangeSuggestion(BaseModel):
+    """Represents a suggested time range for investigation."""
+    
+    start_time: datetime = Field(..., description="Start time for investigation")
+    end_time: datetime = Field(..., description="End time for investigation")
+    reason: str = Field(..., description="Reason for this time range suggestion")
+
+
+class AlarmHistoryResponse(BaseModel):
+    """Response containing alarm history and related information."""
+    
+    alarm_details: AlarmDetails = Field(..., description="Details about the alarm")
+    history_items: List[AlarmHistoryItem] = Field(default_factory=list, description="List of alarm history items")
+    time_range_suggestions: List[TimeRangeSuggestion] = Field(default_factory=list, description="Suggested time ranges for investigation")
+    has_more_results: bool = Field(default=False, description="Whether more history items are available")
+    message: Optional[str] = Field(None, description="Informational message about the results")
+
+
+class CompositeAlarmComponentResponse(BaseModel):
+    """Response containing component alarm details for a composite alarm."""
+    
+    composite_alarm_name: str = Field(..., description="Name of the composite alarm")
+    component_alarms: List[str] = Field(default_factory=list, description="Names of component alarms")
+    alarm_rule: str = Field(..., description="Rule expression for the composite alarm")
+    component_details: Optional[List[AlarmDetails]] = Field(None, description="Details about component alarms")

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_alarms/tools.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_alarms/tools.py
@@ -1,0 +1,668 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CloudWatch Alarms tools for MCP server."""
+
+import boto3
+import json
+import os
+from datetime import datetime, timedelta
+from botocore.config import Config
+from loguru import logger
+from mcp.server.fastmcp import Context
+from pydantic import Field
+from typing import Dict, Any, Optional, List, Union
+
+from awslabs.cloudwatch_mcp_server import MCP_SERVER_VERSION
+from awslabs.cloudwatch_mcp_server.cloudwatch_alarms.models import (
+    MetricAlarmSummary,
+    CompositeAlarmSummary,
+    ActiveAlarmsResponse,
+    AlarmHistoryItem,
+    AlarmDetails,
+    TimeRangeSuggestion,
+    AlarmHistoryResponse,
+    CompositeAlarmComponentResponse,
+)
+
+
+class CloudWatchAlarmsTools:
+    """CloudWatch Alarms tools for MCP server."""
+    
+    def __init__(self):
+        """Initialize the CloudWatch Alarms client."""
+        # Initialize client
+        aws_region: str = os.environ.get('AWS_REGION', 'us-east-1')
+        config = Config(user_agent_extra=f'awslabs/mcp/cloudwatch-mcp-server/{MCP_SERVER_VERSION}')
+
+        try:
+            if aws_profile := os.environ.get('AWS_PROFILE'):
+                self.cloudwatch_client = boto3.Session(profile_name=aws_profile, region_name=aws_region).client(
+                    'cloudwatch', config=config
+                )
+            else:
+                self.cloudwatch_client = boto3.Session(region_name=aws_region).client('cloudwatch', config=config)
+        except Exception as e:
+            logger.error(f'Error creating cloudwatch client: {str(e)}')
+            raise
+
+    def register(self, mcp):
+        """Register all CloudWatch Alarms tools with the MCP server."""
+        
+        # Register get_active_alarms tool
+        mcp.tool(
+            name='get_active_alarms'
+        )(self.get_active_alarms)
+        
+        # Register get_alarm_history tool
+        mcp.tool(
+            name='get_alarm_history'
+        )(self.get_alarm_history)
+
+    async def get_active_alarms(
+        self,
+        ctx: Context,
+        max_items: Optional[int] = Field(
+            default=50,
+            description="Maximum number of alarms to return (default: 50). Large values may cause context window overflow and impact LLM performance."
+        )
+    ) -> ActiveAlarmsResponse:
+        """Gets all CloudWatch alarms currently in ALARM state.
+
+        This tool retrieves all CloudWatch alarms that are currently in the ALARM state,
+        including both metric alarms and composite alarms. Results are optimized for
+        LLM reasoning with summary-level information.
+
+        Usage: Use this tool to get an overview of all active alarms in your AWS account
+        for troubleshooting, monitoring, and operational awareness.
+
+        Args:
+            max_items: Maximum number of alarms to return (default: 50).
+
+        Returns:
+            ActiveAlarmsResponse: Response containing active alarms.
+
+        Example:
+            result = await get_active_alarms(ctx, max_items=25)
+            if isinstance(result, ActiveAlarmsResponse):
+                print(f"Found {len(result.metric_alarms + result.composite_alarms)} active alarms")
+                for alarm in result.metric_alarms:
+                    print(f"Metric Alarm: {alarm.alarm_name}")
+                for alarm in result.composite_alarms:
+                    print(f"Composite Alarm: {alarm.alarm_name}")
+        """
+        try:
+            # Pydantic Field doesn't automatically fill the required type with default if a value is not provided.
+            # Because of this behavior, checking explicitly if we got what we expected.
+            # if max_items is None or not isinstance(max_items, int):
+            if max_items is None or not isinstance(max_items, int):
+                max_items = 50
+            
+            # Validate max_items parameter
+            if max_items < 1:
+                raise ValueError("max_items must be at least 1")
+            
+            # Use default client
+            cloudwatch_client = self.cloudwatch_client
+            
+            # Fetch active alarms using paginator
+            logger.info(f'Fetching up to {max_items} active alarms')
+            
+            paginator = cloudwatch_client.get_paginator('describe_alarms')
+            page_iterator = paginator.paginate(
+                StateValue='ALARM',
+                AlarmTypes=['CompositeAlarm', 'MetricAlarm'],
+                PaginationConfig={
+                    # Requesting an extra item so that we can evaluate if there's extra
+                    'MaxItems': max_items + 1
+                }
+            )
+            
+            # Collect results
+            metric_alarms = []
+            composite_alarms = []
+            total_items_fetched = 0
+            items_to_return = 0
+            
+            for page in page_iterator:
+                metric_alarms_list = page.get('MetricAlarms', [])
+                composite_alarms_list = page.get('CompositeAlarms', [])
+                
+                total_items_fetched += len(metric_alarms_list) + len(composite_alarms_list)
+                
+                for alarm in metric_alarms_list:
+                    if items_to_return < max_items:
+                        metric_alarms.append(self._transform_metric_alarm(alarm))
+                        items_to_return += 1
+                    else:
+                        break
+                    
+                for alarm in composite_alarms_list:
+                    if items_to_return < max_items:
+                        composite_alarms.append(self._transform_composite_alarm(alarm))
+                        items_to_return += 1
+                    else:
+                        break
+            
+            # Determine if more results are available
+            has_more_results = total_items_fetched > max_items
+            
+            # Handle empty results
+            message = None
+            if items_to_return == 0:
+                message = "No active alarms found"
+            elif has_more_results:
+                message = f"Showing {items_to_return} alarms (more available)"
+            
+            logger.info(f'Found {items_to_return} active alarms ({len(metric_alarms)} metric, {len(composite_alarms)} composite), has_more_results: {has_more_results}')
+            
+            return ActiveAlarmsResponse(
+                metric_alarms=metric_alarms,
+                composite_alarms=composite_alarms,
+                has_more_results=has_more_results,
+                message=message
+            )
+            
+        except Exception as e:
+            logger.error(f'Error in get_active_alarms: {str(e)}')
+            await ctx.error(f'Error getting active alarms: {str(e)}')
+            raise
+
+    async def get_alarm_history(
+        self,
+        ctx: Context,
+        alarm_name: str = Field(
+            ...,
+            description="Name of the alarm to retrieve history for"
+        ),
+        start_time: Optional[str] = Field(
+            default=None,
+            description="The start time for the history query in ISO format (e.g., '2023-01-01T00:00:00Z') or as a datetime object. Defaults to 24 hours ago."
+        ),
+        end_time: Optional[str] = Field(
+            default=None,
+            description="The end time for the history query in ISO format (e.g., '2023-01-01T00:00:00Z') or as a datetime object. Defaults to current time."
+        ),
+        history_item_type: Optional[str] = Field(
+            default=None,
+            description="Type of history items to retrieve. Possible values: 'ConfigurationUpdate', 'StateUpdate', 'Action'. Defaults to 'StateUpdate'."
+        ),
+        max_items: Optional[int] = Field(
+            default=50,
+            description="Maximum number of history items to return (default: 50). Large values may cause context window overflow and impact LLM performance. Adjust time-range to limit responses."
+        ),
+        include_component_alarms: Optional[bool] = Field(
+            default=False,
+            description="For composite alarms, whether to include details about component alarms. Defaults to false."
+        )
+    ) -> Union[AlarmHistoryResponse, CompositeAlarmComponentResponse]:
+        """Gets the history for a CloudWatch alarm with time range suggestions for investigation.
+
+        This tool retrieves the history for a specified CloudWatch alarm, focusing primarily
+        on state transitions to ALARM state. It also provides suggested time ranges for
+        investigation based on the alarm's configuration and history.
+
+        Usage: Use this tool to understand when an alarm fired and get useful time ranges
+        for investigating the underlying issue using other CloudWatch tools. The tool is
+        particularly useful for identifying patterns like alarm flapping (going in and out
+        of alarm state frequently).
+
+        Args:
+            alarm_name: Name of the alarm to retrieve history for.
+            start_time: Optional start time for the history query. Defaults to 24 hours ago.
+            end_time: Optional end time for the history query. Defaults to current time.
+            history_item_type: Optional type of history items to retrieve. Defaults to 'StateUpdate'.
+            max_items: Maximum number of history items to return. Defaults to 50.
+            include_component_alarms: For composite alarms, whether to include details about component alarms.
+
+        Returns:
+            Union[AlarmHistoryResponse, CompositeAlarmComponentResponse]: Either a response containing
+            alarm history with time range suggestions, or component alarm details for composite alarms.
+
+        Example:
+            result = await get_alarm_history(
+                ctx,
+                alarm_name="my-cpu-alarm",
+                start_time="2025-06-18T00:00:00Z",
+                end_time="2025-06-19T00:00:00Z"
+            )
+            if isinstance(result, AlarmHistoryResponse):
+                print(f"Found {len(result.history_items)} history items")
+                for suggestion in result.time_range_suggestions:
+                    print(f"Suggested investigation time range: {suggestion.start_time} to {suggestion.end_time}")
+        """
+        try:
+            # Handle FieldInfo objects - set default values
+            if max_items is None or not isinstance(max_items, int):
+                max_items = 50
+            if include_component_alarms is None or not isinstance(include_component_alarms, bool):
+                include_component_alarms = False
+            if history_item_type is None or not isinstance(history_item_type, str):
+                history_item_type = 'StateUpdate'
+            
+            # Use default client
+            cloudwatch_client = self.cloudwatch_client
+            
+            # Set up default time range (last 24 hours)
+            if end_time is None or not isinstance(end_time, str):
+                end_time = datetime.now()
+            else:
+                end_time = datetime.fromisoformat(end_time.replace('Z', '+00:00'))
+            
+            if start_time is None or not isinstance(start_time, str):
+                start_time = end_time - timedelta(days=1)
+            else:
+                start_time = datetime.fromisoformat(start_time.replace('Z', '+00:00'))
+            
+            logger.info(f'Fetching alarm history for {alarm_name}')
+            logger.info(f'Time range: {start_time} to {end_time}')
+            
+            paginator = cloudwatch_client.get_paginator('describe_alarm_history')
+            page_iterator = paginator.paginate(
+                AlarmName=alarm_name,
+                StartDate=start_time,
+                EndDate=end_time,
+                HistoryItemType=history_item_type,
+                PaginationConfig={
+                    'MaxItems': max_items + 1
+                }
+            )
+            
+            # Collect results
+            history_items = []
+            total_items_fetched = 0
+            items_to_return = 0
+            
+            for page in page_iterator:
+                items_list = page.get('AlarmHistoryItems', [])
+                total_items_fetched += len(items_list)
+                
+                for item in items_list:
+                    if items_to_return < max_items:
+                        history_item = self._transform_history_item(item)
+                        history_items.append(history_item)
+                        items_to_return += 1
+                    else:
+                        break
+            
+            # Determine if more results are available
+            has_more_results = total_items_fetched > max_items
+            
+            # Get detailed alarm information
+            alarm_details = await self._get_alarm_details(cloudwatch_client, alarm_name)
+            
+            # Handle composite alarms if requested
+            if include_component_alarms and alarm_details.alarm_type == "CompositeAlarm":
+                return await self._handle_composite_alarm(cloudwatch_client, alarm_details)
+            
+            # Generate time range suggestions based on alarm history and configuration
+            time_range_suggestions = self._generate_time_range_suggestions(history_items, alarm_details)
+            
+            # Create basic response
+            message = None
+            if items_to_return == 0:
+                message = f"No alarm history found for {alarm_name} in the specified time range"
+            elif has_more_results:
+                message = f"Showing {items_to_return} history items (more available)"
+            
+            logger.info(f'Found {items_to_return} alarm history items, has_more_results: {has_more_results}')
+            
+            return AlarmHistoryResponse(
+                alarm_details=alarm_details,
+                history_items=history_items,
+                time_range_suggestions=time_range_suggestions,
+                has_more_results=has_more_results,
+                message=message
+            )
+            
+        except Exception as e:
+            logger.error(f'Error in get_alarm_history: {str(e)}')
+            await ctx.error(f'Error getting alarm history: {str(e)}')
+            raise
+
+
+
+    def _transform_metric_alarm(self, alarm: Dict[str, Any]) -> MetricAlarmSummary:
+        """Transform AWS SDK metric alarm to summary model."""
+        # Extract key dimensions only
+        dimensions = []
+        for dim in alarm.get('Dimensions', []):
+            dimensions.append({
+                'Name': dim.get('Name', ''),
+                'Value': dim.get('Value', '')
+            })
+        
+        return MetricAlarmSummary(
+            alarm_name=alarm.get('AlarmName', ''),
+            alarm_description=alarm.get('AlarmDescription'),
+            state_value=alarm.get('StateValue', ''),
+            state_reason=alarm.get('StateReason', ''),
+            metric_name=alarm.get('MetricName', ''),
+            namespace=alarm.get('Namespace', ''),
+            dimensions=dimensions,
+            threshold=float(alarm.get('Threshold', 0)),
+            comparison_operator=alarm.get('ComparisonOperator', ''),
+            state_updated_timestamp=alarm.get('StateUpdatedTimestamp', datetime.now())
+        )
+
+    def _transform_composite_alarm(self, alarm: Dict[str, Any]) -> CompositeAlarmSummary:
+        """Transform AWS SDK composite alarm to summary model."""
+        return CompositeAlarmSummary(
+            alarm_name=alarm.get('AlarmName', ''),
+            alarm_description=alarm.get('AlarmDescription'),
+            state_value=alarm.get('StateValue', ''),
+            state_reason=alarm.get('StateReason', ''),
+            alarm_rule=alarm.get('AlarmRule', ''),
+            state_updated_timestamp=alarm.get('StateUpdatedTimestamp', datetime.now())
+        )
+
+    async def _get_alarm_details(self, cloudwatch_client, alarm_name: str) -> AlarmDetails:
+        """Retrieve detailed information about a CloudWatch alarm."""
+        try:
+            logger.info(f'Fetching alarm details for {alarm_name}')
+            
+            # Call DescribeAlarms API for the specific alarm
+            response = cloudwatch_client.describe_alarms(
+                AlarmNames=[alarm_name],
+                AlarmTypes=['MetricAlarm', 'CompositeAlarm']
+            )
+            
+            # Check if alarm exists
+            metric_alarms = response.get('MetricAlarms', [])
+            composite_alarms = response.get('CompositeAlarms', [])
+            
+            if not metric_alarms and not composite_alarms:
+                logger.warning(f'Alarm {alarm_name} not found')
+                return AlarmDetails(
+                    alarm_name=alarm_name,
+                    alarm_type="Unknown",
+                    current_state="Unknown",
+                    alarm_description="Alarm not found"
+                )
+            
+            # Process metric alarm
+            if metric_alarms:
+                alarm = metric_alarms[0]
+                
+                # Extract dimensions
+                dimensions = []
+                for dim in alarm.get('Dimensions', []):
+                    dimensions.append({
+                        dim.get('Name', ''): dim.get('Value', '')
+                    })
+                
+                return AlarmDetails(
+                    alarm_name=alarm.get('AlarmName', ''),
+                    alarm_description=alarm.get('AlarmDescription'),
+                    alarm_type="MetricAlarm",
+                    current_state=alarm.get('StateValue', ''),
+                    metric_name=alarm.get('MetricName'),
+                    namespace=alarm.get('Namespace'),
+                    dimensions=dimensions,
+                    threshold=alarm.get('Threshold'),
+                    comparison_operator=alarm.get('ComparisonOperator'),
+                    evaluation_periods=alarm.get('EvaluationPeriods'),
+                    period=alarm.get('Period'),
+                    statistic=alarm.get('Statistic')
+                )
+            
+            # Process composite alarm
+            elif composite_alarms:
+                alarm = composite_alarms[0]
+                
+                return AlarmDetails(
+                    alarm_name=alarm.get('AlarmName', ''),
+                    alarm_description=alarm.get('AlarmDescription'),
+                    alarm_type="CompositeAlarm",
+                    current_state=alarm.get('StateValue', ''),
+                    alarm_rule=alarm.get('AlarmRule')
+                )
+            
+        except Exception as e:
+            logger.error(f'Error fetching alarm details for {alarm_name}: {str(e)}')
+            # Return basic details on error
+            return AlarmDetails(
+                alarm_name=alarm_name,
+                alarm_type="Unknown",
+                current_state="Unknown",
+                alarm_description=f"Error retrieving alarm details: {str(e)}"
+            )
+
+    def _transform_history_item(self, item: Dict[str, Any]) -> AlarmHistoryItem:
+        """Parse and transform a CloudWatch alarm history item."""
+        try:
+            # Extract basic information
+            alarm_name = item.get('AlarmName', '')
+            alarm_type = item.get('AlarmType', '')
+            timestamp = item.get('Timestamp', datetime.now())
+            history_item_type = item.get('HistoryItemType', '')
+            history_summary = item.get('HistorySummary', '')
+            history_data = item.get('HistoryData', '')
+            
+            # Initialize state information
+            old_state = None
+            new_state = None
+            state_reason = None
+            
+            # Parse HistoryData JSON for StateUpdate items
+            if history_item_type == 'StateUpdate' and history_data:
+                try:
+                    data = json.loads(history_data)
+                    
+                    # Extract old state information
+                    if 'oldState' in data:
+                        old_state_info = data['oldState']
+                        old_state = old_state_info.get('stateValue')
+                    
+                    # Extract new state information
+                    if 'newState' in data:
+                        new_state_info = data['newState']
+                        new_state = new_state_info.get('stateValue')
+                        state_reason = new_state_info.get('stateReason')
+                    
+                except json.JSONDecodeError as e:
+                    logger.warning(f'Failed to parse HistoryData JSON for {alarm_name}: {str(e)}')
+                    # Continue with basic information even if JSON parsing fails
+                except Exception as e:
+                    logger.warning(f'Error processing HistoryData for {alarm_name}: {str(e)}')
+            
+            return AlarmHistoryItem(
+                alarm_name=alarm_name,
+                alarm_type=alarm_type,
+                timestamp=timestamp,
+                history_item_type=history_item_type,
+                history_summary=history_summary,
+                old_state=old_state,
+                new_state=new_state,
+                state_reason=state_reason
+            )
+            
+        except Exception as e:
+            logger.error(f'Error transforming history item: {str(e)}')
+            # Return basic item on error
+            return AlarmHistoryItem(
+                alarm_name=item.get('AlarmName', ''),
+                alarm_type=item.get('AlarmType', ''),
+                timestamp=item.get('Timestamp', datetime.now()),
+                history_item_type=item.get('HistoryItemType', ''),
+                history_summary=item.get('HistorySummary', ''),
+                old_state=None,
+                new_state=None,
+                state_reason=None
+            )
+
+    def _generate_time_range_suggestions(self, history_items: List[AlarmHistoryItem], alarm_details: AlarmDetails) -> List[TimeRangeSuggestion]:
+        """Generate time range suggestions based on alarm history and configuration."""
+        try:
+            suggestions = []
+            
+            # Filter for state transitions to ALARM state
+            alarm_transitions = []
+            for item in history_items:
+                if (item.history_item_type == 'StateUpdate' and 
+                    item.new_state == 'ALARM'):
+                    alarm_transitions.append(item)
+            
+            if not alarm_transitions:
+                logger.info('No transitions to ALARM state found')
+                return suggestions
+            
+            # Get alarm configuration for time window calculation
+            period = alarm_details.period or 300  # Default to 5 minutes if not available
+            evaluation_periods = alarm_details.evaluation_periods or 1
+            
+            # Calculate dynamic window based on alarm period (up to 5x the evaluation period)
+            window_before_seconds = period * evaluation_periods * 5
+            window_after_seconds = period * 2
+            
+            logger.info(f'Using dynamic window: {window_before_seconds}s before, {window_after_seconds}s after alarm transitions')
+            
+            # Generate suggestions for each alarm transition
+            for transition in alarm_transitions:
+                start_time = transition.timestamp - timedelta(seconds=window_before_seconds)
+                end_time = transition.timestamp + timedelta(seconds=window_after_seconds)
+                
+                reason = f"Investigation window for alarm transition to ALARM state at {transition.timestamp.strftime('%Y-%m-%d %H:%M:%S UTC')} (based on {evaluation_periods} evaluation periods of {period}s each)"
+                
+                suggestions.append(TimeRangeSuggestion(
+                    start_time=start_time,
+                    end_time=end_time,
+                    reason=reason
+                ))
+            
+            # Check for alarm flapping (multiple transitions in a short time)
+            if len(alarm_transitions) > 1:
+                # Sort transitions by timestamp
+                sorted_transitions = sorted(alarm_transitions, key=lambda x: x.timestamp)
+                
+                # Look for clusters of transitions within a short time window
+                flapping_clusters = []
+                current_cluster = [sorted_transitions[0]]
+                
+                for i in range(1, len(sorted_transitions)):
+                    time_diff = (sorted_transitions[i].timestamp - current_cluster[-1].timestamp).total_seconds()
+                    
+                    # If transitions are within 1 hour of each other, consider them part of the same cluster
+                    if time_diff <= 3600:  # 1 hour
+                        current_cluster.append(sorted_transitions[i])
+                    else:
+                        if len(current_cluster) > 1:
+                            flapping_clusters.append(current_cluster)
+                        current_cluster = [sorted_transitions[i]]
+                
+                # Don't forget the last cluster
+                if len(current_cluster) > 1:
+                    flapping_clusters.append(current_cluster)
+                
+                # Generate suggestions for flapping clusters
+                for cluster in flapping_clusters:
+                    cluster_start = cluster[0].timestamp - timedelta(seconds=window_before_seconds)
+                    cluster_end = cluster[-1].timestamp + timedelta(seconds=window_after_seconds)
+                    
+                    reason = f"Alarm flapping detected: {len(cluster)} transitions to ALARM state between {cluster[0].timestamp.strftime('%Y-%m-%d %H:%M:%S UTC')} and {cluster[-1].timestamp.strftime('%Y-%m-%d %H:%M:%S UTC')}"
+                    
+                    suggestions.append(TimeRangeSuggestion(
+                        start_time=cluster_start,
+                        end_time=cluster_end,
+                        reason=reason
+                    ))
+            
+            logger.info(f'Generated {len(suggestions)} time range suggestions')
+            return suggestions
+            
+        except Exception as e:
+            logger.error(f'Error generating time range suggestions: {str(e)}')
+            return []
+
+    async def _handle_composite_alarm(self, cloudwatch_client, alarm_details: AlarmDetails) -> CompositeAlarmComponentResponse:
+        """Handle composite alarm component details retrieval."""
+        try:
+            logger.info(f'Handling composite alarm: {alarm_details.alarm_name}')
+            
+            # Parse the alarm rule to identify component alarms
+            component_alarms = self._parse_alarm_rule(alarm_details.alarm_rule or '')
+            
+            # Get details about component alarms
+            component_details = []
+            if component_alarms:
+                logger.info(f'Found {len(component_alarms)} component alarms')
+                
+                for component_name in component_alarms:
+                    try:
+                        component_detail = await self._get_alarm_details(cloudwatch_client, component_name)
+                        component_details.append(component_detail)
+                    except Exception as e:
+                        logger.warning(f'Failed to get details for component alarm {component_name}: {str(e)}')
+                        # Add basic details for failed component
+                        component_details.append(AlarmDetails(
+                            alarm_name=component_name,
+                            alarm_type="Unknown",
+                            current_state="Unknown",
+                            alarm_description=f"Failed to retrieve details: {str(e)}"
+                        ))
+            
+            return CompositeAlarmComponentResponse(
+                composite_alarm_name=alarm_details.alarm_name,
+                component_alarms=component_alarms,
+                alarm_rule=alarm_details.alarm_rule or '',
+                component_details=component_details
+            )
+            
+        except Exception as e:
+            logger.error(f'Error handling composite alarm {alarm_details.alarm_name}: {str(e)}')
+            # Return basic response on error
+            return CompositeAlarmComponentResponse(
+                composite_alarm_name=alarm_details.alarm_name,
+                component_alarms=[],
+                alarm_rule=alarm_details.alarm_rule or '',
+                component_details=None
+            )
+
+    def _parse_alarm_rule(self, alarm_rule: str) -> List[str]:
+        """Parse composite alarm rule to extract component alarm names."""
+        try:
+            if not alarm_rule:
+                return []
+            
+            # Simple regex-based parsing to extract alarm names
+            # Composite alarm rules typically contain alarm names in quotes or as identifiers
+            import re
+            
+            # Pattern to match alarm names in various formats:
+            # - Quoted names: "alarm-name"
+            # - ALARM() function: ALARM("alarm-name")
+            # - Direct references: alarm-name (without spaces)
+            patterns = [
+                r'ALARM\("([^"]+)"\)',  # ALARM("alarm-name")
+                r'"([^"]+)"',           # "alarm-name"
+                r'ALARM\(([^)]+)\)',    # ALARM(alarm-name) without quotes
+            ]
+            
+            component_alarms = set()  # Use set to avoid duplicates
+            
+            for pattern in patterns:
+                matches = re.findall(pattern, alarm_rule)
+                for match in matches:
+                    # Clean up the alarm name
+                    alarm_name = match.strip().strip('"').strip("'")
+                    if alarm_name:
+                        component_alarms.add(alarm_name)
+            
+            result = list(component_alarms)
+            logger.info(f'Parsed {len(result)} component alarms from rule: {result}')
+            return result
+            
+        except Exception as e:
+            logger.error(f'Error parsing alarm rule: {str(e)}')
+            return []

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_metrics/models.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_metrics/models.py
@@ -18,7 +18,6 @@ from pydantic import BaseModel, Field
 from typing import Optional, List, Dict, Any, Union
 from datetime import datetime
 
-
 class Dimension(BaseModel):
     """Represents a CloudWatch metric dimension for input parameters."""
 

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/server.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/server.py
@@ -16,20 +16,21 @@
 
 from awslabs.cloudwatch_mcp_server.cloudwatch_logs.tools import CloudWatchLogsTools
 from awslabs.cloudwatch_mcp_server.cloudwatch_metrics.tools import CloudWatchMetricsTools
+from awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools import CloudWatchAlarmsTools
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
 
 
 mcp = FastMCP(
     'awslabs.cloudwatch-mcp-server',
-    instructions='Use this MCP server to run read-only commands and analyze CloudWatchLogs. Supports discovering logs groups as well as running CloudWatch Log Insight Queries. With CloudWatch Logs Insights, you can interactively search and analyze your log data in Amazon CloudWatch Logs and perform queries to help you more efficiently and effectively respond to operational issues.',
+    instructions='Use this MCP server to run read-only commands and analyze CloudWatch Logs, Metrics, and Alarms. Supports discovering log groups, running CloudWatch Log Insight Queries, retrieving CloudWatch Metrics information, and getting active alarms with region information. With CloudWatch Logs Insights, you can interactively search and analyze your log data. With CloudWatch Metrics, you can get information about system and application metrics. With CloudWatch Alarms, you can retrieve all currently active alarms for operational awareness, with clear indication of which AWS region was checked.',
     dependencies=[
         'pydantic',
         'loguru',
     ],
 )
 
-# Initialize and register CloudWatch Logs tools
+# Initialize and register CloudWatch tools
 try:
     cloudwatch_logs_tools = CloudWatchLogsTools()
     cloudwatch_logs_tools.register(mcp)
@@ -37,10 +38,12 @@ try:
     cloudwatch_metrics_tools = CloudWatchMetricsTools()
     cloudwatch_metrics_tools.register(mcp)
     logger.info('CloudWatch Metrics tools registered successfully')
+    cloudwatch_alarms_tools = CloudWatchAlarmsTools()
+    cloudwatch_alarms_tools.register(mcp)
+    logger.info('CloudWatch Alarms tools registered successfully')
 except Exception as e:
     logger.error(f'Error initializing CloudWatch tools: {str(e)}')
     raise
-
 
 def main():
     """Run the MCP server."""

--- a/src/cloudwatch-mcp-server/tests/cloudwatch_alarms/test_active_alarms.py
+++ b/src/cloudwatch-mcp-server/tests/cloudwatch_alarms/test_active_alarms.py
@@ -1,0 +1,533 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for CloudWatch active alarms functionality."""
+
+import pytest
+from datetime import datetime
+from unittest.mock import Mock, patch, AsyncMock
+
+from awslabs.cloudwatch_mcp_server.cloudwatch_alarms.models import (
+    ActiveAlarmsResponse
+)
+from awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools import CloudWatchAlarmsTools
+
+
+@pytest.fixture
+def mock_context():
+    """Create mock MCP context."""
+    context = Mock()
+    context.info = AsyncMock()
+    context.warning = AsyncMock()
+    context.error = AsyncMock()
+    return context
+
+
+class TestGetActiveAlarms:
+    """Test cases for get_active_alarms functionality."""
+
+    @pytest.mark.asyncio
+    async def test_max_items_validation_valid(self, mock_context):
+        """Test max_items parameter validation with valid values."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [{'MetricAlarms': [], 'CompositeAlarms': []}]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Test valid max_items values
+            result = await alarms_tools.get_active_alarms(mock_context, max_items=25)
+            assert isinstance(result, ActiveAlarmsResponse)
+            
+            result = await alarms_tools.get_active_alarms(mock_context, max_items=1)
+            assert isinstance(result, ActiveAlarmsResponse)
+
+    @pytest.mark.asyncio
+    async def test_max_items_validation_invalid(self, mock_context):
+        """Test max_items parameter validation with invalid values."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Test invalid max_items values
+            with pytest.raises(ValueError, match="max_items must be at least 1"):
+                await alarms_tools.get_active_alarms(mock_context, max_items=0)
+            
+            with pytest.raises(ValueError, match="max_items must be at least 1"):
+                await alarms_tools.get_active_alarms(mock_context, max_items=-1)
+
+    @pytest.mark.asyncio
+    async def test_no_max_items_works_correctly(self, mock_context):
+        """Test that boto3 paginator is used correctly."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [{
+                'MetricAlarms': [{
+                    'AlarmName': 'test-alarm',
+                    'StateValue': 'ALARM',
+                    'StateReason': 'Test reason',
+                    'MetricName': 'CPUUtilization',
+                    'Namespace': 'AWS/EC2',
+                    'Dimensions': [],
+                    'Threshold': 80.0,
+                    'ComparisonOperator': 'GreaterThanThreshold',
+                    'StateUpdatedTimestamp': datetime.now()
+                }],
+                'CompositeAlarms': []
+            }]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            result = await alarms_tools.get_active_alarms(mock_context)
+            
+            # Verify paginator was used
+            mock_client.get_paginator.assert_called_once_with('describe_alarms')
+            mock_paginator.paginate.assert_called_once_with(
+                StateValue='ALARM',
+                AlarmTypes=['CompositeAlarm', 'MetricAlarm'],
+                PaginationConfig={'MaxItems': 51}
+            )
+            
+            assert isinstance(result, ActiveAlarmsResponse)
+            assert len(result.metric_alarms) == 1
+            # Verify total_count is not in response
+            assert not hasattr(result, 'total_count')
+
+    @pytest.mark.asyncio
+    async def test_paginator_usage(self, mock_context):
+        """Test that boto3 paginator is used correctly."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [{
+                'MetricAlarms': [{
+                    'AlarmName': 'test-alarm',
+                    'StateValue': 'ALARM',
+                    'StateReason': 'Test reason',
+                    'MetricName': 'CPUUtilization',
+                    'Namespace': 'AWS/EC2',
+                    'Dimensions': [],
+                    'Threshold': 80.0,
+                    'ComparisonOperator': 'GreaterThanThreshold',
+                    'StateUpdatedTimestamp': datetime.now()
+                }],
+                'CompositeAlarms': []
+            }]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            result = await alarms_tools.get_active_alarms(mock_context, max_items=50)
+            
+            # Verify paginator was used
+            mock_client.get_paginator.assert_called_once_with('describe_alarms')
+            mock_paginator.paginate.assert_called_once_with(
+                StateValue='ALARM',
+                AlarmTypes=['CompositeAlarm', 'MetricAlarm'],
+                PaginationConfig={'MaxItems': 51}
+            )
+            
+            assert isinstance(result, ActiveAlarmsResponse)
+            assert len(result.metric_alarms) == 1
+            # Verify total_count is not in response
+            assert not hasattr(result, 'total_count')
+
+    def test_describe_alarms_parameters(self):
+        """Test that describe_alarms is called with the correct parameters."""
+        # Create a mock client
+        mock_client = Mock()
+        
+        # Set up the return value
+        mock_client.describe_alarms.return_value = {
+            'MetricAlarms': [],
+            'CompositeAlarms': []
+        }
+        
+        # Call describe_alarms
+        mock_client.describe_alarms(
+            StateValue='ALARM',
+            MaxRecords=50,
+            AlarmTypes=['CompositeAlarm', 'MetricAlarm']
+        )
+        
+        # Verify the call
+        mock_client.describe_alarms.assert_called_once_with(
+            StateValue='ALARM',
+            MaxRecords=50,
+            AlarmTypes=['CompositeAlarm', 'MetricAlarm']
+        )
+        
+    def test_default_region_usage(self):
+        """Test that default region from environment is used."""
+        # Test that the tool uses the region from environment/initialization
+        with patch.dict('os.environ', {'AWS_REGION': 'us-west-2'}):
+            with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+                mock_client = Mock()
+                mock_session.return_value.client.return_value = mock_client
+                
+                # Create tools instance - should use environment region
+                alarms_tools = CloudWatchAlarmsTools()
+                
+                # Verify session was created with correct region
+                mock_session.assert_called_with(region_name='us-west-2')
+        
+
+    def test_alarm_tools_registration(self):
+        """Test that CloudWatchAlarmsTools registers both alarm tools."""
+        # Create a mock MCP
+        mock_mcp = Mock()
+        
+        # Mock boto3 session to avoid AWS credential errors
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            # Setup mock client
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            # Create a CloudWatchAlarmsTools instance
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Mock the methods
+            alarms_tools.get_active_alarms = Mock()
+            alarms_tools.get_alarm_history = Mock()
+            
+            # Register the tools
+            alarms_tools.register(mock_mcp)
+            
+            # Verify that both tools were registered
+            assert mock_mcp.tool.call_count == 2
+            calls = mock_mcp.tool.call_args_list
+            call_names = [call[1]['name'] for call in calls]
+            assert 'get_active_alarms' in call_names
+            assert 'get_alarm_history' in call_names
+
+    @pytest.mark.asyncio
+    async def test_empty_alarms_response(self, mock_context):
+        """Test handling of empty alarms response."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [{'MetricAlarms': [], 'CompositeAlarms': []}]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            result = await alarms_tools.get_active_alarms(mock_context, max_items=50)
+            
+            assert isinstance(result, ActiveAlarmsResponse)
+            assert len(result.metric_alarms) == 0
+            assert len(result.composite_alarms) == 0
+            assert result.message == "No active alarms found"
+            assert not result.has_more_results
+
+    @pytest.mark.asyncio
+    async def test_mixed_alarm_types_response(self, mock_context):
+        """Test response with both metric and composite alarms."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [{
+                'MetricAlarms': [{
+                    'AlarmName': 'metric-alarm',
+                    'StateValue': 'ALARM',
+                    'StateReason': 'Metric alarm reason',
+                    'MetricName': 'CPUUtilization',
+                    'Namespace': 'AWS/EC2',
+                    'Dimensions': [{'Name': 'InstanceId', 'Value': 'i-123'}],
+                    'Threshold': 80.0,
+                    'ComparisonOperator': 'GreaterThanThreshold',
+                    'StateUpdatedTimestamp': datetime.now()
+                }],
+                'CompositeAlarms': [{
+                    'AlarmName': 'composite-alarm',
+                    'StateValue': 'ALARM',
+                    'StateReason': 'Composite alarm reason',
+                    'AlarmRule': 'ALARM("metric-alarm")',
+                    'StateUpdatedTimestamp': datetime.now()
+                }]
+            }]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            result = await alarms_tools.get_active_alarms(mock_context, max_items=50)
+            
+            assert isinstance(result, ActiveAlarmsResponse)
+            assert len(result.metric_alarms) == 1
+            assert len(result.composite_alarms) == 1
+            assert result.metric_alarms[0].alarm_name == 'metric-alarm'
+            assert result.composite_alarms[0].alarm_name == 'composite-alarm'
+
+    @pytest.mark.asyncio
+    async def test_has_more_results_logic(self, mock_context):
+        """Test has_more_results logic when max_items is exceeded."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_paginator = Mock()
+            # Return 3 alarms when max_items=2
+            mock_paginator.paginate.return_value = [{
+                'MetricAlarms': [
+                    {'AlarmName': 'alarm1', 'StateValue': 'ALARM', 'StateReason': 'reason1',
+                     'MetricName': 'CPU', 'Namespace': 'AWS/EC2', 'Dimensions': [],
+                     'Threshold': 80.0, 'ComparisonOperator': 'GreaterThanThreshold',
+                     'StateUpdatedTimestamp': datetime.now()},
+                    {'AlarmName': 'alarm2', 'StateValue': 'ALARM', 'StateReason': 'reason2',
+                     'MetricName': 'CPU', 'Namespace': 'AWS/EC2', 'Dimensions': [],
+                     'Threshold': 80.0, 'ComparisonOperator': 'GreaterThanThreshold',
+                     'StateUpdatedTimestamp': datetime.now()},
+                    {'AlarmName': 'alarm3', 'StateValue': 'ALARM', 'StateReason': 'reason3',
+                     'MetricName': 'CPU', 'Namespace': 'AWS/EC2', 'Dimensions': [],
+                     'Threshold': 80.0, 'ComparisonOperator': 'GreaterThanThreshold',
+                     'StateUpdatedTimestamp': datetime.now()}
+                ],
+                'CompositeAlarms': []
+            }]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            result = await alarms_tools.get_active_alarms(mock_context, max_items=2)
+            
+            assert isinstance(result, ActiveAlarmsResponse)
+            assert len(result.metric_alarms) == 2  # Only 2 returned despite 3 available
+            assert result.has_more_results == True
+            assert "Showing 2 alarms (more available)" in result.message
+
+    @pytest.mark.asyncio
+    async def test_aws_profile_initialization(self, mock_context):
+        """Test initialization with AWS_PROFILE environment variable."""
+        with patch.dict('os.environ', {'AWS_PROFILE': 'test-profile', 'AWS_REGION': 'us-west-2'}):
+            with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+                mock_client = Mock()
+                mock_paginator = Mock()
+                mock_paginator.paginate.return_value = [{'MetricAlarms': [], 'CompositeAlarms': []}]
+                mock_client.get_paginator.return_value = mock_paginator
+                mock_session.return_value.client.return_value = mock_client
+                
+                alarms_tools = CloudWatchAlarmsTools()
+                await alarms_tools.get_active_alarms(mock_context, max_items=50)
+                
+                # Verify session was created with profile
+                mock_session.assert_called_with(profile_name='test-profile', region_name='us-west-2')
+
+    @pytest.mark.asyncio
+    async def test_boto3_client_error_handling(self, mock_context):
+        """Test error handling when boto3 client fails."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_session.side_effect = Exception("AWS credentials not found")
+            
+            with pytest.raises(Exception, match="AWS credentials not found"):
+                CloudWatchAlarmsTools()
+
+    @pytest.mark.asyncio
+    async def test_describe_alarms_api_error(self, mock_context):
+        """Test error handling when describe_alarms API fails."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_paginator = Mock()
+            mock_paginator.paginate.side_effect = Exception("API Error")
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            with pytest.raises(Exception, match="API Error"):
+                await alarms_tools.get_active_alarms(mock_context, max_items=50)
+            
+            # Verify error was logged to context
+            mock_context.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_alarm_transformation_with_missing_fields(self, mock_context):
+        """Test alarm transformation handles missing optional fields gracefully."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_paginator = Mock()
+            # Alarm with minimal required fields
+            mock_paginator.paginate.return_value = [{
+                'MetricAlarms': [{
+                    'AlarmName': 'minimal-alarm',
+                    'StateValue': 'ALARM',
+                    # Missing optional fields like AlarmDescription, Dimensions, etc.
+                }],
+                'CompositeAlarms': [{
+                    'AlarmName': 'minimal-composite',
+                    'StateValue': 'ALARM',
+                    # Missing optional fields
+                }]
+            }]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            result = await alarms_tools.get_active_alarms(mock_context, max_items=50)
+            
+            assert isinstance(result, ActiveAlarmsResponse)
+            assert len(result.metric_alarms) == 1
+            assert len(result.composite_alarms) == 1
+            
+            # Check that missing fields are handled with defaults
+            metric_alarm = result.metric_alarms[0]
+            assert metric_alarm.alarm_name == 'minimal-alarm'
+            assert metric_alarm.alarm_description is None
+            assert metric_alarm.dimensions == []
+            
+            composite_alarm = result.composite_alarms[0]
+            assert composite_alarm.alarm_name == 'minimal-composite'
+            assert composite_alarm.alarm_description is None
+
+    @pytest.mark.asyncio
+    async def test_pagination_across_multiple_pages(self, mock_context):
+        """Test pagination handling across multiple pages."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_paginator = Mock()
+            # Simulate multiple pages
+            mock_paginator.paginate.return_value = [
+                {
+                    'MetricAlarms': [{
+                        'AlarmName': 'alarm-page1',
+                        'StateValue': 'ALARM',
+                        'StateReason': 'reason1',
+                        'MetricName': 'CPU',
+                        'Namespace': 'AWS/EC2',
+                        'Dimensions': [],
+                        'Threshold': 80.0,
+                        'ComparisonOperator': 'GreaterThanThreshold',
+                        'StateUpdatedTimestamp': datetime.now()
+                    }],
+                    'CompositeAlarms': []
+                },
+                {
+                    'MetricAlarms': [{
+                        'AlarmName': 'alarm-page2',
+                        'StateValue': 'ALARM',
+                        'StateReason': 'reason2',
+                        'MetricName': 'Memory',
+                        'Namespace': 'AWS/EC2',
+                        'Dimensions': [],
+                        'Threshold': 90.0,
+                        'ComparisonOperator': 'GreaterThanThreshold',
+                        'StateUpdatedTimestamp': datetime.now()
+                    }],
+                    'CompositeAlarms': []
+                }
+            ]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            result = await alarms_tools.get_active_alarms(mock_context, max_items=5)
+            
+            assert isinstance(result, ActiveAlarmsResponse)
+            assert len(result.metric_alarms) == 2
+            assert result.metric_alarms[0].alarm_name == 'alarm-page1'
+            assert result.metric_alarms[1].alarm_name == 'alarm-page2'
+
+    @pytest.mark.asyncio
+    async def test_dimension_transformation(self, mock_context):
+        """Test proper transformation of alarm dimensions."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [{
+                'MetricAlarms': [{
+                    'AlarmName': 'alarm-with-dimensions',
+                    'StateValue': 'ALARM',
+                    'StateReason': 'Test reason',
+                    'MetricName': 'CPUUtilization',
+                    'Namespace': 'AWS/EC2',
+                    'Dimensions': [
+                        {'Name': 'InstanceId', 'Value': 'i-1234567890abcdef0'},
+                        {'Name': 'AutoScalingGroupName', 'Value': 'my-asg'}
+                    ],
+                    'Threshold': 80.0,
+                    'ComparisonOperator': 'GreaterThanThreshold',
+                    'StateUpdatedTimestamp': datetime.now()
+                }],
+                'CompositeAlarms': []
+            }]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            result = await alarms_tools.get_active_alarms(mock_context, max_items=50)
+            
+            assert isinstance(result, ActiveAlarmsResponse)
+            assert len(result.metric_alarms) == 1
+            
+            alarm = result.metric_alarms[0]
+            assert len(alarm.dimensions) == 2
+            assert alarm.dimensions[0] == {'Name': 'InstanceId', 'Value': 'i-1234567890abcdef0'}
+            assert alarm.dimensions[1] == {'Name': 'AutoScalingGroupName', 'Value': 'my-asg'}
+
+    def test_transform_metric_alarm_direct(self):
+        """Test _transform_metric_alarm method directly."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            alarm_data = {
+                'AlarmName': 'test-alarm',
+                'AlarmDescription': 'Test description',
+                'StateValue': 'ALARM',
+                'StateReason': 'Test reason',
+                'MetricName': 'CPUUtilization',
+                'Namespace': 'AWS/EC2',
+                'Dimensions': [{'Name': 'InstanceId', 'Value': 'i-123'}],
+                'Threshold': 75.5,
+                'ComparisonOperator': 'GreaterThanThreshold',
+                'StateUpdatedTimestamp': datetime(2023, 1, 1, 12, 0, 0)
+            }
+            
+            result = alarms_tools._transform_metric_alarm(alarm_data)
+            
+            assert result.alarm_name == 'test-alarm'
+            assert result.alarm_description == 'Test description'
+            assert result.state_value == 'ALARM'
+            assert result.threshold == 75.5
+            assert len(result.dimensions) == 1
+
+    def test_transform_composite_alarm_direct(self):
+        """Test _transform_composite_alarm method directly."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            alarm_data = {
+                'AlarmName': 'composite-test',
+                'AlarmDescription': 'Composite description',
+                'StateValue': 'ALARM',
+                'StateReason': 'Composite reason',
+                'AlarmRule': 'ALARM("alarm1") OR ALARM("alarm2")',
+                'StateUpdatedTimestamp': datetime(2023, 1, 1, 12, 0, 0)
+            }
+            
+            result = alarms_tools._transform_composite_alarm(alarm_data)
+            
+            assert result.alarm_name == 'composite-test'
+            assert result.alarm_description == 'Composite description'
+            assert result.state_value == 'ALARM'
+            assert result.alarm_rule == 'ALARM("alarm1") OR ALARM("alarm2")'
+            assert result.alarm_type == 'CompositeAlarm'

--- a/src/cloudwatch-mcp-server/tests/cloudwatch_alarms/test_alarm_history.py
+++ b/src/cloudwatch-mcp-server/tests/cloudwatch_alarms/test_alarm_history.py
@@ -1,0 +1,484 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for CloudWatch alarm history functionality."""
+
+import pytest
+import json
+from datetime import datetime, timedelta
+from unittest.mock import Mock, patch, AsyncMock
+
+from awslabs.cloudwatch_mcp_server.cloudwatch_alarms.models import (
+    AlarmHistoryResponse,
+    CompositeAlarmComponentResponse,
+    AlarmHistoryItem,
+    AlarmDetails,
+    TimeRangeSuggestion
+)
+from awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools import CloudWatchAlarmsTools
+
+
+@pytest.fixture
+def mock_context():
+    """Create mock MCP context."""
+    context = Mock()
+    context.info = AsyncMock()
+    context.warning = AsyncMock()
+    context.error = AsyncMock()
+    return context
+
+
+@pytest.fixture
+def sample_alarm_history_response():
+    """Sample CloudWatch GetAlarmHistory API response."""
+    return {
+        'AlarmHistoryItems': [
+            {
+                'AlarmName': 'test-alarm',
+                'AlarmType': 'MetricAlarm',
+                'Timestamp': datetime(2025, 6, 20, 10, 0, 0),
+                'HistoryItemType': 'StateUpdate',
+                'HistorySummary': 'Alarm updated from OK to ALARM',
+                'HistoryData': json.dumps({
+                    'oldState': {'stateValue': 'OK'},
+                    'newState': {'stateValue': 'ALARM', 'stateReason': 'Threshold crossed'}
+                })
+            },
+            {
+                'AlarmName': 'test-alarm',
+                'AlarmType': 'MetricAlarm',
+                'Timestamp': datetime(2025, 6, 20, 9, 0, 0),
+                'HistoryItemType': 'StateUpdate',
+                'HistorySummary': 'Alarm updated from ALARM to OK',
+                'HistoryData': json.dumps({
+                    'oldState': {'stateValue': 'ALARM'},
+                    'newState': {'stateValue': 'OK', 'stateReason': 'Threshold not crossed'}
+                })
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def sample_metric_alarm():
+    """Sample metric alarm from DescribeAlarms API."""
+    return {
+        'AlarmName': 'test-alarm',
+        'AlarmDescription': 'Test alarm description',
+        'StateValue': 'ALARM',
+        'MetricName': 'CPUUtilization',
+        'Namespace': 'AWS/EC2',
+        'Dimensions': [
+            {'Name': 'InstanceId', 'Value': 'i-1234567890abcdef0'}
+        ],
+        'Threshold': 80.0,
+        'ComparisonOperator': 'GreaterThanThreshold',
+        'EvaluationPeriods': 2,
+        'Period': 300,
+        'Statistic': 'Average'
+    }
+
+
+@pytest.fixture
+def sample_composite_alarm():
+    """Sample composite alarm from DescribeAlarms API."""
+    return {
+        'AlarmName': 'composite-alarm',
+        'AlarmDescription': 'Composite alarm description',
+        'StateValue': 'ALARM',
+        'AlarmRule': 'ALARM("alarm1") OR ALARM("alarm2")'
+    }
+
+
+class TestGetAlarmHistory:
+    """Test cases for get_alarm_history functionality."""
+
+    @pytest.mark.asyncio
+    async def test_get_alarm_history_basic_functionality(self, mock_context, sample_alarm_history_response, sample_metric_alarm):
+        """Test basic alarm history retrieval functionality."""
+        # Mock boto3 session and client
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            # Setup paginator mock
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [sample_alarm_history_response]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_client.describe_alarms.return_value = {
+                'MetricAlarms': [sample_metric_alarm],
+                'CompositeAlarms': []
+            }
+            
+            # Create CloudWatchAlarmsTools instance
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Call get_alarm_history
+            result = await alarms_tools.get_alarm_history(
+                ctx=mock_context,
+                alarm_name='test-alarm'
+            )
+            
+            # Verify result type and basic properties
+            assert isinstance(result, AlarmHistoryResponse)
+            assert result.alarm_details.alarm_name == 'test-alarm'
+            assert result.alarm_details.alarm_type == 'MetricAlarm'
+            assert len(result.history_items) == 2
+
+            
+            # Verify API calls
+            mock_client.get_paginator.assert_called_once_with('describe_alarm_history')
+            mock_client.describe_alarms.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_alarm_history_with_custom_parameters(self, mock_context, sample_alarm_history_response, sample_metric_alarm):
+        """Test alarm history with custom parameters."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [sample_alarm_history_response]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_client.describe_alarms.return_value = {
+                'MetricAlarms': [sample_metric_alarm],
+                'CompositeAlarms': []
+            }
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Call with custom parameters
+            result = await alarms_tools.get_alarm_history(
+                ctx=mock_context,
+                alarm_name='test-alarm',
+                start_time='2025-06-20T08:00:00Z',
+                end_time='2025-06-20T12:00:00Z',
+                history_item_type='StateUpdate',
+                max_items=25
+            )
+            
+            assert isinstance(result, AlarmHistoryResponse)
+
+            
+            # Verify paginator call parameters
+            call_args = mock_paginator.paginate.call_args[1]
+            assert call_args['AlarmName'] == 'test-alarm'
+            assert call_args['HistoryItemType'] == 'StateUpdate'
+            assert call_args['PaginationConfig']['MaxItems'] == 26
+
+    @pytest.mark.asyncio
+    async def test_composite_alarm_handling(self, mock_context, sample_composite_alarm):
+        """Test composite alarm component handling."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            # Setup composite alarm response
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [{'AlarmHistoryItems': []}]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_client.describe_alarms.return_value = {
+                'MetricAlarms': [],
+                'CompositeAlarms': [sample_composite_alarm]
+            }
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Call with include_component_alarms=True
+            result = await alarms_tools.get_alarm_history(
+                ctx=mock_context,
+                alarm_name='composite-alarm',
+                include_component_alarms=True
+            )
+            
+            assert isinstance(result, CompositeAlarmComponentResponse)
+            assert result.composite_alarm_name == 'composite-alarm'
+            assert result.alarm_rule == 'ALARM("alarm1") OR ALARM("alarm2")'
+            assert 'alarm1' in result.component_alarms
+            assert 'alarm2' in result.component_alarms
+
+    def test_transform_history_item_with_state_update(self):
+        """Test history item transformation with state update data."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session'):
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Sample history item with state update
+            history_item = {
+                'AlarmName': 'test-alarm',
+                'AlarmType': 'MetricAlarm',
+                'Timestamp': datetime(2025, 6, 20, 10, 0, 0),
+                'HistoryItemType': 'StateUpdate',
+                'HistorySummary': 'Alarm updated from OK to ALARM',
+                'HistoryData': json.dumps({
+                    'oldState': {'stateValue': 'OK'},
+                    'newState': {'stateValue': 'ALARM', 'stateReason': 'Threshold crossed'}
+                })
+            }
+            
+            result = alarms_tools._transform_history_item(history_item)
+            
+            assert isinstance(result, AlarmHistoryItem)
+            assert result.alarm_name == 'test-alarm'
+            assert result.old_state == 'OK'
+            assert result.new_state == 'ALARM'
+            assert result.state_reason == 'Threshold crossed'
+
+    def test_transform_history_item_with_invalid_json(self):
+        """Test history item transformation with invalid JSON."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session'):
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Sample history item with invalid JSON
+            history_item = {
+                'AlarmName': 'test-alarm',
+                'AlarmType': 'MetricAlarm',
+                'Timestamp': datetime(2025, 6, 20, 10, 0, 0),
+                'HistoryItemType': 'StateUpdate',
+                'HistorySummary': 'Alarm updated',
+                'HistoryData': 'invalid json'
+            }
+            
+            result = alarms_tools._transform_history_item(history_item)
+            
+            assert isinstance(result, AlarmHistoryItem)
+            assert result.alarm_name == 'test-alarm'
+            assert result.old_state is None
+            assert result.new_state is None
+            assert result.state_reason is None
+
+    def test_generate_time_range_suggestions(self):
+        """Test time range suggestion generation."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session'):
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Create sample history items with ALARM transitions
+            history_items = [
+                AlarmHistoryItem(
+                    alarm_name='test-alarm',
+                    alarm_type='MetricAlarm',
+                    timestamp=datetime(2025, 6, 20, 10, 0, 0),
+                    history_item_type='StateUpdate',
+                    history_summary='Alarm updated',
+                    old_state='OK',
+                    new_state='ALARM',
+                    state_reason='Threshold crossed'
+                )
+            ]
+            
+            # Create alarm details
+            alarm_details = AlarmDetails(
+                alarm_name='test-alarm',
+                alarm_type='MetricAlarm',
+                current_state='ALARM',
+                period=300,
+                evaluation_periods=2
+            )
+            
+            suggestions = alarms_tools._generate_time_range_suggestions(history_items, alarm_details)
+            
+            assert len(suggestions) == 1
+            assert isinstance(suggestions[0], TimeRangeSuggestion)
+            
+            # Verify time range calculation (5 * period * evaluation_periods before, 2 * period after)
+            expected_start = datetime(2025, 6, 20, 10, 0, 0) - timedelta(seconds=300 * 2 * 5)  # 50 minutes before
+            expected_end = datetime(2025, 6, 20, 10, 0, 0) + timedelta(seconds=300 * 2)  # 10 minutes after
+            
+            assert suggestions[0].start_time == expected_start
+            assert suggestions[0].end_time == expected_end
+
+    def test_generate_time_range_suggestions_with_flapping(self):
+        """Test time range suggestions with alarm flapping detection."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session'):
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Create multiple ALARM transitions within short time (flapping)
+            base_time = datetime(2025, 6, 20, 10, 0, 0)
+            history_items = [
+                AlarmHistoryItem(
+                    alarm_name='test-alarm',
+                    alarm_type='MetricAlarm',
+                    timestamp=base_time,
+                    history_item_type='StateUpdate',
+                    history_summary='Alarm updated',
+                    old_state='OK',
+                    new_state='ALARM',
+                    state_reason='Threshold crossed'
+                ),
+                AlarmHistoryItem(
+                    alarm_name='test-alarm',
+                    alarm_type='MetricAlarm',
+                    timestamp=base_time + timedelta(minutes=10),
+                    history_item_type='StateUpdate',
+                    history_summary='Alarm updated',
+                    old_state='OK',
+                    new_state='ALARM',
+                    state_reason='Threshold crossed'
+                )
+            ]
+            
+            alarm_details = AlarmDetails(
+                alarm_name='test-alarm',
+                alarm_type='MetricAlarm',
+                current_state='ALARM',
+                period=300,
+                evaluation_periods=1
+            )
+            
+            suggestions = alarms_tools._generate_time_range_suggestions(history_items, alarm_details)
+            
+            # Should have individual suggestions plus flapping cluster suggestion
+            assert len(suggestions) >= 2
+            
+            # Check for flapping detection in reasons
+            flapping_suggestions = [s for s in suggestions if 'flapping' in s.reason.lower()]
+            assert len(flapping_suggestions) >= 1
+
+    def test_parse_alarm_rule(self):
+        """Test composite alarm rule parsing."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session'):
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Test various alarm rule formats
+            test_cases = [
+                ('ALARM("alarm1") OR ALARM("alarm2")', ['alarm1', 'alarm2']),
+                ('ALARM("single-alarm")', ['single-alarm']),
+                ('ALARM("alarm-1") AND ALARM("alarm-2") OR ALARM("alarm-3")', ['alarm-1', 'alarm-2', 'alarm-3']),
+                ('', []),
+                ('ALARM(alarm-without-quotes)', ['alarm-without-quotes'])
+            ]
+            
+            for rule, expected_alarms in test_cases:
+                result = alarms_tools._parse_alarm_rule(rule)
+                assert set(result) == set(expected_alarms), f"Failed for rule: {rule}"
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self, mock_context):
+        """Test error handling in get_alarm_history."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            # Setup paginator to raise an exception
+            mock_paginator = Mock()
+            mock_paginator.paginate.side_effect = Exception("Access denied")
+            mock_client.get_paginator.return_value = mock_paginator
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Should raise exception since error handling raises
+            with pytest.raises(Exception, match="Access denied"):
+                await alarms_tools.get_alarm_history(
+                    ctx=mock_context,
+                    alarm_name='test-alarm'
+                )
+            
+            # Verify error was logged
+            mock_context.error.assert_called_once()
+
+    def test_alarm_tools_registration_includes_history(self):
+        """Test that CloudWatchAlarmsTools registers the get_alarm_history tool."""
+        mock_mcp = Mock()
+        
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            alarms_tools.get_alarm_history = Mock()
+            
+            alarms_tools.register(mock_mcp)
+            
+            # Verify both tools are registered
+            assert mock_mcp.tool.call_count == 2
+            tool_calls = [call[1]['name'] for call in mock_mcp.tool.call_args_list]
+            assert 'get_active_alarms' in tool_calls
+            assert 'get_alarm_history' in tool_calls
+
+    def test_region_handling(self):
+        """Test region handling from environment configuration."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            # Test default region when no environment variable is set
+            with patch.dict('os.environ', {}, clear=True):
+                alarms_tools = CloudWatchAlarmsTools()
+                # Should use default us-east-1
+                mock_session.assert_called_with(region_name='us-east-1')
+            
+            # Test custom region from environment
+            with patch.dict('os.environ', {'AWS_REGION': 'eu-west-1'}):
+                alarms_tools = CloudWatchAlarmsTools()
+                # Should use environment region
+                mock_session.assert_called_with(region_name='eu-west-1')
+
+
+class TestAlarmHistoryEdgeCases:
+    """Test edge cases for alarm history functionality."""
+
+    def test_empty_history_response(self):
+        """Test handling of empty alarm history."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session'):
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Test with empty history items
+            suggestions = alarms_tools._generate_time_range_suggestions([], AlarmDetails(
+                alarm_name='test',
+                alarm_type='MetricAlarm',
+                current_state='OK'
+            ))
+            
+            assert suggestions == []
+
+    def test_history_item_with_missing_fields(self):
+        """Test history item transformation with missing fields."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session'):
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # History item with minimal fields
+            history_item = {
+                'AlarmName': 'test-alarm'
+                # Missing other fields
+            }
+            
+            result = alarms_tools._transform_history_item(history_item)
+            
+            assert isinstance(result, AlarmHistoryItem)
+            assert result.alarm_name == 'test-alarm'
+            assert result.alarm_type == ''
+            assert result.history_item_type == ''
+
+    def test_alarm_details_not_found(self):
+        """Test alarm details retrieval when alarm doesn't exist."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            # Setup empty response (alarm not found)
+            mock_client.describe_alarms.return_value = {
+                'MetricAlarms': [],
+                'CompositeAlarms': []
+            }
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # This should be an async call
+            import asyncio
+            result = asyncio.run(alarms_tools._get_alarm_details(mock_client, 'nonexistent-alarm'))
+            
+            assert isinstance(result, AlarmDetails)
+            assert result.alarm_name == 'nonexistent-alarm'
+            assert result.alarm_type == 'Unknown'
+            assert result.current_state == 'Unknown'
+            assert 'not found' in result.alarm_description.lower()

--- a/src/cloudwatch-mcp-server/tests/cloudwatch_alarms/test_alarm_history_integration.py
+++ b/src/cloudwatch-mcp-server/tests/cloudwatch_alarms/test_alarm_history_integration.py
@@ -1,0 +1,645 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for CloudWatch alarm history functionality."""
+
+import pytest
+import json
+from datetime import datetime, timedelta
+from unittest.mock import Mock, patch, AsyncMock
+
+from awslabs.cloudwatch_mcp_server.cloudwatch_alarms.models import (
+    AlarmHistoryResponse,
+    CompositeAlarmComponentResponse
+)
+from awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools import CloudWatchAlarmsTools
+
+
+@pytest.fixture
+def mock_context():
+    """Create mock MCP context."""
+    context = Mock()
+    context.info = AsyncMock()
+    context.warning = AsyncMock()
+    context.error = AsyncMock()
+    return context
+
+
+@pytest.fixture
+def realistic_alarm_history_response():
+    """Realistic CloudWatch GetAlarmHistory API response with multiple state changes."""
+    base_time = datetime(2025, 6, 20, 10, 0, 0)
+    return {
+        'AlarmHistoryItems': [
+            {
+                'AlarmName': 'web-server-cpu-alarm',
+                'AlarmType': 'MetricAlarm',
+                'Timestamp': base_time,
+                'HistoryItemType': 'StateUpdate',
+                'HistorySummary': 'Alarm updated from OK to ALARM',
+                'HistoryData': json.dumps({
+                    'oldState': {
+                        'stateValue': 'OK',
+                        'stateReason': 'Threshold Crossed: 1 out of the last 1 datapoints [45.2] was not greater than the threshold (80.0) (minimum 1 datapoint for OK -> ALARM transition).'
+                    },
+                    'newState': {
+                        'stateValue': 'ALARM',
+                        'stateReason': 'Threshold Crossed: 2 consecutive datapoints [85.4, 87.1] were greater than the threshold (80.0) (minimum 2 datapoints for ALARM transition).'
+                    }
+                })
+            },
+            {
+                'AlarmName': 'web-server-cpu-alarm',
+                'AlarmType': 'MetricAlarm',
+                'Timestamp': base_time - timedelta(minutes=15),
+                'HistoryItemType': 'StateUpdate',
+                'HistorySummary': 'Alarm updated from ALARM to OK',
+                'HistoryData': json.dumps({
+                    'oldState': {
+                        'stateValue': 'ALARM',
+                        'stateReason': 'Threshold Crossed: 2 consecutive datapoints [85.4, 87.1] were greater than the threshold (80.0).'
+                    },
+                    'newState': {
+                        'stateValue': 'OK',
+                        'stateReason': 'Threshold Crossed: 1 out of the last 1 datapoints [45.2] was not greater than the threshold (80.0).'
+                    }
+                })
+            },
+            {
+                'AlarmName': 'web-server-cpu-alarm',
+                'AlarmType': 'MetricAlarm',
+                'Timestamp': base_time - timedelta(minutes=30),
+                'HistoryItemType': 'StateUpdate',
+                'HistorySummary': 'Alarm updated from OK to ALARM',
+                'HistoryData': json.dumps({
+                    'oldState': {
+                        'stateValue': 'OK',
+                        'stateReason': 'Threshold Crossed: 1 out of the last 1 datapoints [45.2] was not greater than the threshold (80.0).'
+                    },
+                    'newState': {
+                        'stateValue': 'ALARM',
+                        'stateReason': 'Threshold Crossed: 2 consecutive datapoints [82.3, 84.7] were greater than the threshold (80.0).'
+                    }
+                })
+            },
+            {
+                'AlarmName': 'web-server-cpu-alarm',
+                'AlarmType': 'MetricAlarm',
+                'Timestamp': base_time - timedelta(hours=2),
+                'HistoryItemType': 'ConfigurationUpdate',
+                'HistorySummary': 'Alarm threshold updated from 70.0 to 80.0',
+                'HistoryData': json.dumps({
+                    'updatedAlarm': {
+                        'threshold': 80.0,
+                        'comparisonOperator': 'GreaterThanThreshold'
+                    }
+                })
+            }
+        ],
+        'NextToken': 'next-page-token-123'
+    }
+
+
+@pytest.fixture
+def realistic_metric_alarm():
+    """Realistic metric alarm configuration."""
+    return {
+        'AlarmName': 'web-server-cpu-alarm',
+        'AlarmDescription': 'Monitors CPU utilization for web server instances',
+        'StateValue': 'ALARM',
+        'StateReason': 'Threshold Crossed: 2 consecutive datapoints [85.4, 87.1] were greater than the threshold (80.0).',
+        'StateUpdatedTimestamp': datetime(2025, 6, 20, 10, 0, 0),
+        'MetricName': 'CPUUtilization',
+        'Namespace': 'AWS/EC2',
+        'Dimensions': [
+            {'Name': 'InstanceId', 'Value': 'i-1234567890abcdef0'},
+            {'Name': 'AutoScalingGroupName', 'Value': 'web-server-asg'}
+        ],
+        'Threshold': 80.0,
+        'ComparisonOperator': 'GreaterThanThreshold',
+        'EvaluationPeriods': 2,
+        'Period': 300,
+        'Statistic': 'Average',
+        'TreatMissingData': 'notBreaching',
+        'ActionsEnabled': True,
+        'AlarmActions': [
+            'arn:aws:sns:us-east-1:123456789012:cpu-alarm-topic'
+        ]
+    }
+
+
+@pytest.fixture
+def realistic_composite_alarm():
+    """Realistic composite alarm configuration."""
+    return {
+        'AlarmName': 'application-health-composite',
+        'AlarmDescription': 'Overall application health based on multiple metrics',
+        'StateValue': 'ALARM',
+        'StateReason': 'ALARM("web-server-cpu-alarm") is in ALARM',
+        'StateUpdatedTimestamp': datetime(2025, 6, 20, 10, 0, 0),
+        'AlarmRule': '(ALARM("web-server-cpu-alarm") OR ALARM("database-connection-alarm")) AND NOT ALARM("maintenance-mode-alarm")',
+        'ActionsEnabled': True,
+        'AlarmActions': [
+            'arn:aws:sns:us-east-1:123456789012:critical-alert-topic'
+        ]
+    }
+
+
+class TestAlarmHistoryIntegration:
+    """Integration tests for alarm history functionality."""
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_metric_alarm_history(self, mock_context, realistic_alarm_history_response, realistic_metric_alarm):
+        """Test complete end-to-end alarm history retrieval for metric alarm."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            # Setup realistic API responses - simulate more items than max_items (50)
+            # Create a response with 51 items to trigger has_more_results=True
+            extended_response = realistic_alarm_history_response.copy()
+            # Add extra items to simulate pagination
+            for i in range(47):  # Add 47 more items (4 existing + 47 = 51 total)
+                extended_response['AlarmHistoryItems'].append({
+                    'AlarmName': 'web-server-cpu-alarm',
+                    'AlarmType': 'MetricAlarm',
+                    'Timestamp': datetime(2025, 6, 20, 8, 0, 0) - timedelta(minutes=i),
+                    'HistoryItemType': 'StateUpdate',
+                    'HistorySummary': f'Extra item {i}',
+                    'HistoryData': '{}'
+                })
+            
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [extended_response]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_client.describe_alarms.return_value = {
+                'MetricAlarms': [realistic_metric_alarm],
+                'CompositeAlarms': []
+            }
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Call with realistic parameters
+            result = await alarms_tools.get_alarm_history(
+                ctx=mock_context,
+                alarm_name='web-server-cpu-alarm',
+                start_time='2025-06-20T06:00:00Z',
+                end_time='2025-06-20T12:00:00Z'
+            )
+            
+            # Verify comprehensive response
+            assert isinstance(result, AlarmHistoryResponse)
+            assert result.has_more_results == True
+            
+            # Verify alarm details
+            assert result.alarm_details.alarm_name == 'web-server-cpu-alarm'
+            assert result.alarm_details.alarm_type == 'MetricAlarm'
+            assert result.alarm_details.metric_name == 'CPUUtilization'
+            assert result.alarm_details.namespace == 'AWS/EC2'
+            assert result.alarm_details.threshold == 80.0
+            assert result.alarm_details.period == 300
+            assert result.alarm_details.evaluation_periods == 2
+            
+            # Verify history items parsing (limited to max_items=50)
+            assert len(result.history_items) == 50
+            
+            # Check state update items (first few are the original ones)
+            state_updates = [item for item in result.history_items if item.history_item_type == 'StateUpdate']
+            assert len(state_updates) >= 3  # At least the original 3
+            
+            # Verify ALARM transitions (from original items)
+            alarm_transitions = [item for item in state_updates if item.new_state == 'ALARM']
+            assert len(alarm_transitions) >= 2  # At least the original 2
+            
+            # Verify time range suggestions
+            assert len(result.time_range_suggestions) >= 2  # At least individual suggestions
+            
+            # Check for flapping detection (2 ALARM transitions within 30 minutes)
+            flapping_suggestions = [s for s in result.time_range_suggestions if 'flapping' in s.reason.lower()]
+            assert len(flapping_suggestions) >= 1
+            
+            # Verify time range calculation
+            for suggestion in result.time_range_suggestions:
+                assert isinstance(suggestion.start_time, datetime)
+                assert isinstance(suggestion.end_time, datetime)
+                assert suggestion.start_time < suggestion.end_time
+                assert len(suggestion.reason) > 0
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_composite_alarm_with_components(self, mock_context, realistic_composite_alarm, realistic_metric_alarm):
+        """Test complete composite alarm handling with component expansion."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            # Setup composite alarm response
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [{'AlarmHistoryItems': []}]
+            mock_client.get_paginator.return_value = mock_paginator
+            
+            # First call returns composite alarm, subsequent calls return component alarms
+            describe_calls = [
+                {
+                    'MetricAlarms': [],
+                    'CompositeAlarms': [realistic_composite_alarm]
+                },
+                {  # For web-server-cpu-alarm
+                    'MetricAlarms': [realistic_metric_alarm],
+                    'CompositeAlarms': []
+                },
+                {  # For database-connection-alarm
+                    'MetricAlarms': [{
+                        'AlarmName': 'database-connection-alarm',
+                        'AlarmDescription': 'Database connection monitoring',
+                        'StateValue': 'OK',
+                        'MetricName': 'DatabaseConnections',
+                        'Namespace': 'AWS/RDS',
+                        'Threshold': 80.0,
+                        'ComparisonOperator': 'GreaterThanThreshold',
+                        'EvaluationPeriods': 1,
+                        'Period': 300,
+                        'Statistic': 'Average'
+                    }],
+                    'CompositeAlarms': []
+                },
+                {  # For maintenance-mode-alarm
+                    'MetricAlarms': [{
+                        'AlarmName': 'maintenance-mode-alarm',
+                        'AlarmDescription': 'Maintenance mode indicator',
+                        'StateValue': 'OK',
+                        'MetricName': 'MaintenanceMode',
+                        'Namespace': 'Custom/Application',
+                        'Threshold': 1.0,
+                        'ComparisonOperator': 'GreaterThanOrEqualToThreshold',
+                        'EvaluationPeriods': 1,
+                        'Period': 60,
+                        'Statistic': 'Maximum'
+                    }],
+                    'CompositeAlarms': []
+                }
+            ]
+            
+            mock_client.describe_alarms.side_effect = describe_calls
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Call with component expansion
+            result = await alarms_tools.get_alarm_history(
+                ctx=mock_context,
+                alarm_name='application-health-composite',
+                include_component_alarms=True
+            )
+            
+            # Verify composite alarm response
+            assert isinstance(result, CompositeAlarmComponentResponse)
+            assert result.composite_alarm_name == 'application-health-composite'
+            
+            # Verify alarm rule parsing
+            expected_components = ['web-server-cpu-alarm', 'database-connection-alarm', 'maintenance-mode-alarm']
+            assert set(result.component_alarms) == set(expected_components)
+            
+            # Verify component details
+            assert result.component_details is not None
+            assert len(result.component_details) == 3
+            
+            # Check each component
+            component_names = [detail.alarm_name for detail in result.component_details]
+            assert 'web-server-cpu-alarm' in component_names
+            assert 'database-connection-alarm' in component_names
+            assert 'maintenance-mode-alarm' in component_names
+
+    @pytest.mark.asyncio
+    async def test_pagination_handling(self, mock_context, realistic_alarm_history_response, realistic_metric_alarm):
+        """Test pagination handling in alarm history."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            # Setup paginated response - simulate more items than max_items (50)
+            extended_response = realistic_alarm_history_response.copy()
+            # Add extra items to simulate pagination
+            for i in range(47):  # Add 47 more items (4 existing + 47 = 51 total)
+                extended_response['AlarmHistoryItems'].append({
+                    'AlarmName': 'web-server-cpu-alarm',
+                    'AlarmType': 'MetricAlarm',
+                    'Timestamp': datetime(2025, 6, 20, 8, 0, 0) - timedelta(minutes=i),
+                    'HistoryItemType': 'StateUpdate',
+                    'HistorySummary': f'Extra item {i}',
+                    'HistoryData': '{}'
+                })
+            
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [extended_response]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_client.describe_alarms.return_value = {
+                'MetricAlarms': [realistic_metric_alarm],
+                'CompositeAlarms': []
+            }
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            result = await alarms_tools.get_alarm_history(
+                ctx=mock_context,
+                alarm_name='web-server-cpu-alarm',
+                max_items=50
+            )
+            
+            assert isinstance(result, AlarmHistoryResponse)
+            assert result.has_more_results == True
+            assert 'more available' in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_different_history_item_types(self, mock_context, realistic_metric_alarm):
+        """Test handling of different history item types."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            # Setup response with different item types
+            mixed_history_response = {
+                'AlarmHistoryItems': [
+                    {
+                        'AlarmName': 'test-alarm',
+                        'AlarmType': 'MetricAlarm',
+                        'Timestamp': datetime(2025, 6, 20, 10, 0, 0),
+                        'HistoryItemType': 'StateUpdate',
+                        'HistorySummary': 'State updated',
+                        'HistoryData': json.dumps({
+                            'oldState': {'stateValue': 'OK'},
+                            'newState': {'stateValue': 'ALARM', 'stateReason': 'Threshold crossed'}
+                        })
+                    },
+                    {
+                        'AlarmName': 'test-alarm',
+                        'AlarmType': 'MetricAlarm',
+                        'Timestamp': datetime(2025, 6, 20, 9, 0, 0),
+                        'HistoryItemType': 'ConfigurationUpdate',
+                        'HistorySummary': 'Alarm threshold updated',
+                        'HistoryData': json.dumps({
+                            'updatedAlarm': {'threshold': 80.0}
+                        })
+                    },
+                    {
+                        'AlarmName': 'test-alarm',
+                        'AlarmType': 'MetricAlarm',
+                        'Timestamp': datetime(2025, 6, 20, 8, 0, 0),
+                        'HistoryItemType': 'Action',
+                        'HistorySummary': 'SNS notification sent',
+                        'HistoryData': json.dumps({
+                            'actionExecuted': {
+                                'actionArn': 'arn:aws:sns:us-east-1:123456789012:alarm-topic'
+                            }
+                        })
+                    }
+                ]
+            }
+            
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [mixed_history_response]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_client.describe_alarms.return_value = {
+                'MetricAlarms': [realistic_metric_alarm],
+                'CompositeAlarms': []
+            }
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Test with different history item types
+            for item_type in ['StateUpdate', 'ConfigurationUpdate', 'Action']:
+                result = await alarms_tools.get_alarm_history(
+                    ctx=mock_context,
+                    alarm_name='test-alarm',
+                    history_item_type=item_type
+                )
+                
+                assert isinstance(result, AlarmHistoryResponse)
+                # Verify paginator was called with correct item type
+                call_args = mock_paginator.paginate.call_args[1]
+                assert call_args['HistoryItemType'] == item_type
+
+    @pytest.mark.asyncio
+    async def test_error_scenarios_integration(self, mock_context):
+        """Test various error scenarios in integration context."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Test alarm not found
+            mock_paginator = Mock()
+            mock_paginator.paginate.side_effect = Exception("ResourceNotFound")
+            mock_client.get_paginator.return_value = mock_paginator
+            
+            # Should raise exception since error handling raises
+            with pytest.raises(Exception, match="ResourceNotFound"):
+                await alarms_tools.get_alarm_history(
+                    ctx=mock_context,
+                    alarm_name='nonexistent-alarm'
+                )
+            
+            # Verify error was logged
+            mock_context.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_time_range_edge_cases(self, mock_context, realistic_metric_alarm):
+        """Test edge cases in time range handling."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [{'AlarmHistoryItems': []}]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_client.describe_alarms.return_value = {
+                'MetricAlarms': [realistic_metric_alarm],
+                'CompositeAlarms': []
+            }
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Test with various time formats
+            time_formats = [
+                ('2025-06-20T08:00:00Z', '2025-06-20T12:00:00Z'),
+                ('2025-06-20T08:00:00+00:00', '2025-06-20T12:00:00+00:00'),
+                ('2025-06-20T08:00:00-05:00', '2025-06-20T12:00:00-05:00'),
+            ]
+            
+            for start_time, end_time in time_formats:
+                result = await alarms_tools.get_alarm_history(
+                    ctx=mock_context,
+                    alarm_name='test-alarm',
+                    start_time=start_time,
+                    end_time=end_time
+                )
+                
+                assert isinstance(result, AlarmHistoryResponse)
+                
+                # Verify paginator call parameters
+                call_args = mock_paginator.paginate.call_args[1]
+                assert 'StartDate' in call_args
+                assert 'EndDate' in call_args
+
+    @pytest.mark.asyncio
+    async def test_environment_region_behavior(self, mock_context, realistic_alarm_history_response, realistic_metric_alarm):
+        """Test region behavior from environment configuration."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [realistic_alarm_history_response]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_client.describe_alarms.return_value = {
+                'MetricAlarms': [realistic_metric_alarm],
+                'CompositeAlarms': []
+            }
+            
+            # Test different regions via environment
+            regions = ['us-east-1', 'us-west-2', 'eu-west-1', 'ap-southeast-1']
+            
+            for region in regions:
+                with patch.dict('os.environ', {'AWS_REGION': region}):
+                    alarms_tools = CloudWatchAlarmsTools()
+                    
+                    result = await alarms_tools.get_alarm_history(
+                        ctx=mock_context,
+                        alarm_name='test-alarm'
+                    )
+                    
+                    assert isinstance(result, AlarmHistoryResponse)
+                    
+                    # Verify region-specific client creation
+                    mock_session.assert_called()
+
+    def test_complex_alarm_rule_parsing(self):
+        """Test parsing of complex composite alarm rules."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session'):
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            # Test complex real-world alarm rules
+            complex_rules = [
+                (
+                    '(ALARM("web-server-cpu-alarm") OR ALARM("web-server-memory-alarm")) AND NOT ALARM("maintenance-mode")',
+                    ['web-server-cpu-alarm', 'web-server-memory-alarm', 'maintenance-mode']
+                ),
+                (
+                    'ALARM("primary-db-alarm") AND (ALARM("replica-1-alarm") OR ALARM("replica-2-alarm"))',
+                    ['primary-db-alarm', 'replica-1-alarm', 'replica-2-alarm']
+                ),
+                (
+                    '((ALARM("app-server-1") OR ALARM("app-server-2")) AND ALARM("load-balancer")) OR ALARM("critical-service")',
+                    ['app-server-1', 'app-server-2', 'load-balancer', 'critical-service']
+                )
+            ]
+            
+            for rule, expected_alarms in complex_rules:
+                result = alarms_tools._parse_alarm_rule(rule)
+                assert set(result) == set(expected_alarms), f"Failed for complex rule: {rule}"
+
+    @pytest.mark.asyncio
+    async def test_performance_with_large_history(self, mock_context, realistic_metric_alarm):
+        """Test performance considerations with large alarm history."""
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            mock_client = Mock()
+            mock_session.return_value.client.return_value = mock_client
+            
+            # Create large history response (simulating busy alarm)
+            base_time = datetime(2025, 6, 20, 10, 0, 0)
+            large_history = {
+                'AlarmHistoryItems': []
+            }
+            
+            # Generate 100 history items (alternating states)
+            for i in range(100):
+                timestamp = base_time - timedelta(minutes=i*5)
+                old_state = 'ALARM' if i % 2 == 0 else 'OK'
+                new_state = 'OK' if i % 2 == 0 else 'ALARM'
+                
+                large_history['AlarmHistoryItems'].append({
+                    'AlarmName': 'busy-alarm',
+                    'AlarmType': 'MetricAlarm',
+                    'Timestamp': timestamp,
+                    'HistoryItemType': 'StateUpdate',
+                    'HistorySummary': f'Alarm updated from {old_state} to {new_state}',
+                    'HistoryData': json.dumps({
+                        'oldState': {'stateValue': old_state},
+                        'newState': {'stateValue': new_state, 'stateReason': 'Threshold crossed'}
+                    })
+                })
+            
+            mock_paginator = Mock()
+            mock_paginator.paginate.return_value = [large_history]
+            mock_client.get_paginator.return_value = mock_paginator
+            mock_client.describe_alarms.return_value = {
+                'MetricAlarms': [realistic_metric_alarm],
+                'CompositeAlarms': []
+            }
+            
+            alarms_tools = CloudWatchAlarmsTools()
+            
+            result = await alarms_tools.get_alarm_history(
+                ctx=mock_context,
+                alarm_name='busy-alarm',
+                max_items=100
+            )
+            
+            assert isinstance(result, AlarmHistoryResponse)
+            assert len(result.history_items) == 100
+            
+            # Should detect significant flapping
+            flapping_suggestions = [s for s in result.time_range_suggestions if 'flapping' in s.reason.lower()]
+            assert len(flapping_suggestions) > 0
+            
+            # Verify performance - should complete without timeout
+            # (This is implicit - if the test completes, performance is acceptable)
+
+    @pytest.mark.asyncio
+    async def test_default_time_range_behavior(self, mock_context, realistic_metric_alarm):
+        """Test behavior when no start and end times are provided with mocked datetime."""
+        fixed_now = datetime(2025, 6, 20, 15, 30, 0)
+        expected_start = fixed_now - timedelta(hours=24)
+        
+        with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.boto3.Session') as mock_session:
+            with patch('awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools.datetime') as mock_datetime:
+                mock_client = Mock()
+                mock_session.return_value.client.return_value = mock_client
+                
+                # Mock datetime.now() to return fixed time
+                mock_datetime.now.return_value = fixed_now
+                mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+                
+                mock_paginator = Mock()
+                mock_paginator.paginate.return_value = [{'AlarmHistoryItems': []}]
+                mock_client.get_paginator.return_value = mock_paginator
+                mock_client.describe_alarms.return_value = {
+                    'MetricAlarms': [realistic_metric_alarm],
+                    'CompositeAlarms': []
+                }
+                
+                alarms_tools = CloudWatchAlarmsTools()
+                
+                result = await alarms_tools.get_alarm_history(
+                    ctx=mock_context,
+                    alarm_name='test-alarm'
+                )
+                
+                assert isinstance(result, AlarmHistoryResponse)
+                
+                # Verify paginator was called with default 24-hour range
+                call_args = mock_paginator.paginate.call_args[1]
+                assert 'StartDate' in call_args
+                assert 'EndDate' in call_args
+                assert call_args['EndDate'] == fixed_now
+                assert call_args['StartDate'] == expected_start


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary

### Changes

Adding support for read operations on CloudWatch alarms. More specifically, added 2 new APIs to the CW server:
1. `get_active_alarms` - retrieves active metric and composite alarms from the AWS account and provides information to the agent for further implementation
2. `get_alarm_history` - a tool to retrieve histories for CW alarms with the aim of understanding the alarm's behavior and suggest investigation times based

### User experience

With this change, customers will be able to interact with the CW MCP server to list and investigate their CW alarms. The LLM agent will receive CW Alarms data as well as suggestions to guide the customer in understanding why the alarms transitioned and how they behave.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X]  Changes are documented

Is this a breaking change? (N)

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
