### PR TITLE
Support Metrics Insights query on the get_metric_data tool

### DIFF
--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_metrics/models.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_metrics/models.py
@@ -15,8 +15,15 @@
 """Data models for CloudWatch Metrics MCP tools."""
 
 from pydantic import BaseModel, Field
-from typing import Optional, List, Dict, Any, Union
+from typing import Optional, List, Dict, Any, Union, Literal
 from datetime import datetime
+from enum import Enum
+
+
+class SortOrder(str, Enum):
+    """Sort order for Metrics Insights queries."""
+    ASCENDING = "ASC"
+    DESCENDING = "DESC"
 
 
 class Dimension(BaseModel):

--- a/src/cloudwatch-mcp-server/tests/cloudwatch_metrics/test_validation_error.py
+++ b/src/cloudwatch-mcp-server/tests/cloudwatch_metrics/test_validation_error.py
@@ -1,0 +1,57 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for validation error in CloudWatch Metrics tools."""
+
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from awslabs.cloudwatch_mcp_server.cloudwatch_metrics.tools import CloudWatchMetricsTools
+
+
+@pytest_asyncio.fixture
+async def ctx():
+    """Fixture to provide mock context."""
+    return AsyncMock()
+
+
+@pytest_asyncio.fixture
+async def cloudwatch_metrics_tools():
+    """Create CloudWatchMetricsTools instance with mocked client."""
+    with patch('awslabs.cloudwatch_mcp_server.cloudwatch_metrics.tools.boto3.Session') as mock_session:
+        mock_session.return_value.client.return_value = MagicMock()
+        tools = CloudWatchMetricsTools()
+        return tools
+
+
+@pytest.mark.asyncio
+class TestValidationError:
+    """Tests for validation error in CloudWatch Metrics tools."""
+
+    async def test_group_by_dimension_not_in_schema_dimension_keys(self, ctx, cloudwatch_metrics_tools):
+        """Test that an error is raised when group_by_dimension is not in schema_dimension_keys."""
+        # Call the tool with group_by_dimension not in schema_dimension_keys
+        with pytest.raises(ValueError) as excinfo:
+            await cloudwatch_metrics_tools.get_metric_data(
+                ctx,
+                namespace='AWS/EC2',
+                metric_name='CPUUtilization',
+                start_time='2023-01-01T00:00:00Z',
+                end_time='2023-01-01T01:00:00Z',
+                statistic='AVG',
+                group_by_dimension='InstanceId',
+                schema_dimension_keys=['InstanceType']  # InstanceId is not in this list
+            )
+        
+        # Verify the error message
+        assert "group_by_dimension 'InstanceId' must be included in schema_dimension_keys" in str(excinfo.value)


### PR DESCRIPTION
# Fixes 
## Summary 
### Changes 
This PR adds support for CloudWatch Metrics Insights queries in the `get_metric_data` tool of the CloudWatch MCP server. It enhances the existing tool to automatically determine whether to use standard GetMetricData API or Metrics Insights based on the parameters provided. 
The PR adds significant new functionality to the CloudWatch MCP server by supporting Metrics Insights queries, which allows for more advanced metric analysis. The implementation automatically determines whether to use standard GetMetricData or Metrics Insights based on the parameters provided, making it seamless for users to leverage the new capabilities.
### User experience 
Before this change, users could only retrieve CloudWatch metrics using the standard GetMetricData API, which limited the ability to perform advanced queries like grouping by dimensions or sorting results. After this change, users can now:
 - Group metrics by dimensions using `group_by_dimension` parameter 
 - Include specific dimensions in the SCHEMA definition using `schema_dimension_keys`
 - Limit the number of results using `limit` parameter 
 - Sort results using `sort_order` parameter (ASC/DESC)
 - Specify a different statistic for ordering using `order_by_statistic`
This provides a much more powerful and flexible way to query CloudWatch metrics, especially for analyzing metrics across multiple resources. 
## Checklist If your change doesn't seem to apply, please leave them unchecked. 
* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md) 
* [x] I have performed a self-review of this change 
* [x] Changes have been tested 
* [x] Changes are documented Is this a breaking change? (Y/N) N **RFC issue number**: N/A Checklist: 
* [ ] Migration process documented 
* [ ] Implement warnings (if it can live side by side) 
## Acknowledgment 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
