### PR TITLE
Deprecate CloudWatch Logs server  and refactor CloudWatch Logs Tools in CloudWatch MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Monitor, optimize, and manage your AWS infrastructure and costs.
 
 - **[Cost Analysis MCP Server](src/cost-analysis-mcp-server/)** - Pre-deployment cost estimation and optimization
 - **[AWS Cost Explorer MCP Server](src/cost-explorer-mcp-server/)** - Detailed cost analysis and reporting
-- **[Amazon CloudWatch MCP Server](src/cloudwatch-mcp-server/)** - Log analysis and operational troubleshooting
+- **[Amazon CloudWatch MCP Server](src/cloudwatch-mcp-server/)** - Metrics, Alarms, and Logs analysis and operational troubleshooting
 - **[Amazon CloudWatch Logs MCP Server (deprecated)](src/cloudwatch-logs-mcp-server/)** - Log analysis and operational troubleshooting
 - **[AWS Managed Prometheus MCP Server](src/prometheus-mcp-server/)** - Prometheus-compatible operations
 
@@ -289,7 +289,7 @@ Monitor, optimize, and manage your AWS infrastructure and costs.
 
 ##### Operations & Monitoring
 
-- **[Amazon CloudWatch MCP Server](src/cloudwatch-mcp-server/)** - Log analysis and operational troubleshooting
+- **[Amazon CloudWatch MCP Server](src/cloudwatch-mcp-server/)** - Metrics, Alarms, and Logs analysis and operational troubleshooting
 - **[Amazon CloudWatch Logs MCP Server (deprecated)](src/cloudwatch-logs-mcp-server/)** - Log analysis and operational troubleshooting
 - **[AWS Cost Explorer MCP Server](src/cost-explorer-mcp-server/)** - Cost monitoring and spend analysis
 - **[AWS Managed Prometheus MCP Server](src/prometheus-mcp-server/)** - Prometheus-compatible operations

--- a/docs/index.md
+++ b/docs/index.md
@@ -312,14 +312,18 @@ A server for Aurora MySql.
 
 ### Amazon CloudWatch MCP Server
 
-An AWS Labs Model Context Protocol (MCP) server for Amazon Cloudwatch Logs.
+An AWS Labs Model Context Protocol (MCP) server for CloudWatch provides AI-powered troubleshooting tools across metrics, alarms, and logs, enabling rapid root cause analysis and intelligent recommendations. It offers comprehensive observability tools that simplify monitoring, reduce context switching, and help teams quickly diagnose and resolve service issues. This server will provide AI agents and application developers with seamless access to CloudWatch telemetry data through standardized MCP interfaces, eliminating the need for custom API solutions and reducing context switching during troubleshooting workflows. By consolidating access to all CloudWatch capabilities, we enable powerful cross-service correlations and insights that accelerate incident resolution and improve operational visibility.
 
 **Features:**
+The CloudWatch MCP Server provides specialized tools to address common operational scenarios including alarm troubleshooting, understand metrics definitions, alarm recommendations and log analysis. Each tool encapsulates one or multiple CloudWatch APIs into task-oriented operations.
 
-- Discover log groups and their metadata
-- Execute CloudWatch Log Insights queries against log groups
+- Alarm Based Troubleshooting - Identifies active alarms, retrieves related metrics and logs, and analyzes historical alarm patterns to determine root causes of triggered alerts. Provides context-aware recommendations for remediation.
 
-Use this MCP server to first discover available logs groups, then run queries on them to filter, analyze, aggregate, etc. logs.
+- Log Analyzer - Analyzes a CloudWatch log group for anomalies, message patterns, and error patterns within a specified time window.
+
+- Metric Definition Analyzer - Provides comprehensive descriptions of what metrics represent, how they're calculated, recommended statistics to use for metric data retrieval
+
+- Alarm Recommendations - Suggests optimal alarm configurations based on best practices. Helps reduce false positives and ensure appropriate coverage of critical metrics.
 
 [Learn more about the Amazon CloudWatch MCP Server](servers/cloudwatch-mcp-server.md)
 

--- a/src/cloudwatch-logs-mcp-server/README.md
+++ b/src/cloudwatch-logs-mcp-server/README.md
@@ -1,6 +1,6 @@
-# AWS Labs cloudwatch-logs MCP Server
+# AWS Labs cloudwatch-logs MCP Server (DEPRECATED)
 
-An AWS Labs Model Context Protocol (MCP) server for cloudwatch-logs
+An AWS Labs Model Context Protocol (MCP) server for cloudwatch-logs. (DEPRECATED). Please use [CloudWatch MCP Server](../../src/cloudwatch-mcp-server/README.md) for unified CloudWatch Telemetry related tools. 
 
 ## Instructions
 
@@ -39,6 +39,8 @@ Log group must have at least one [CloudWatch Log Anomaly Detector](https://docs.
 * `logs:StopQuery`
 
 ## Installation
+
+(DEPRECATED). Please use [CloudWatch MCP Server](../../src/cloudwatch-mcp-server/README.md) for unified CloudWatch Telemetry related tools. 
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=awslabs.cloudwatch-logs-mcp-server&config=eyJhdXRvQXBwcm92ZSI6W10sImRpc2FibGVkIjpmYWxzZSwidGltZW91dCI6NjAsImNvbW1hbmQiOiJ1dnggYXdzbGFicy5jbG91ZHdhdGNoLWxvZ3MtbWNwLXNlcnZlckBsYXRlc3QiLCJlbnYiOnsiQVdTX1BST0ZJTEUiOiJbVGhlIEFXUyBQcm9maWxlIE5hbWUgdG8gdXNlIGZvciBBV1MgYWNjZXNzXSIsIkFXU19SRUdJT04iOiJbVGhlIEFXUyByZWdpb24gdG8gcnVuIGluXSIsIkZBU1RNQ1BfTE9HX0xFVkVMIjoiRVJST1IifSwidHJhbnNwb3J0VHlwZSI6InN0ZGlvIn0%3D)
 

--- a/src/cloudwatch-logs-mcp-server/awslabs/cloudwatch_logs_mcp_server/server.py
+++ b/src/cloudwatch-logs-mcp-server/awslabs/cloudwatch_logs_mcp_server/server.py
@@ -98,7 +98,8 @@ async def describe_log_groups_tool(
         description=('The maximum number of log groups to return.'),
     ),
 ) -> LogMetadata:
-    """Lists AWS CloudWatch log groups and saved queries associated with them, optionally filtering by a name prefix.
+    """IMPORTANT: This tool is deprecated. Please use the describe_log_groups tool in the cloudwatch MCP server instead.
+    Lists AWS CloudWatch log groups and saved queries associated with them, optionally filtering by a name prefix.
 
     This tool retrieves information about log groups in the account, or log groups in accounts linked to this account as a monitoring account.
     If a prefix is provided, only log groups with names starting with the specified prefix are returned.
@@ -199,7 +200,8 @@ async def analyze_log_group_tool(
         ),
     ),
 ) -> LogAnalysisResult:
-    """Analyzes a CloudWatch log group for anomalies, message patterns, and error patterns within a specified time window.
+    """IMPORTANT: This tool is deprecated. Please use the analyze_log_group tool in the cloudwatch MCP server instead.
+    Analyzes a CloudWatch log group for anomalies, message patterns, and error patterns within a specified time window.
 
     This tool performs an analysis of the specified log group by:
     1. Discovering and checking log anomaly detectors associated with the log group
@@ -339,7 +341,8 @@ async def execute_log_insights_query_tool(
         description='Maximum time in second to poll for complete results before giving up',
     ),
 ) -> Dict:
-    """Executes a CloudWatch Logs Insights query and waits for the results to be available.
+    """IMPORTANT: This tool is deprecated. Please use the execute_log_insights_query tool in the cloudwatch MCP server instead.
+    Executes a CloudWatch Logs Insights query and waits for the results to be available.
 
     IMPORTANT: The operation must include exactly one of the following parameters: log_group_names, or log_group_identifiers.
 
@@ -428,7 +431,8 @@ async def get_query_results_tool(
         description='The unique ID of the query to retrieve the results for. CRITICAL: This ID is returned by the execute_log_insights_query tool.',
     ),
 ) -> Dict:
-    """Retrieves the results of a previously started CloudWatch Logs Insights query.
+    """IMPORTANT: This tool is deprecated. Please use the get_logs_insight_query_results tool in the cloudwatch MCP server instead.
+    Retrieves the results of a previously started CloudWatch Logs Insights query.
 
     Usage: If a log query is started by execute_log_insights_query tool and has a polling time out, this tool can be used to try to retrieve
     the query results again.
@@ -469,7 +473,8 @@ async def cancel_query_tool(
         description='The unique ID of the ongoing query to cancel. CRITICAL: This ID is returned by the execute_log_insights_query tool.',
     ),
 ) -> CancelQueryResult:
-    """Cancels an ongoing CloudWatch Logs Insights query. If the query has already ended, returns an error that the given query is not running.
+    """IMPORTANT: This tool is deprecated. Please use the cancel_logs_insight_query tool in the cloudwatch MCP server instead.
+    Cancels an ongoing CloudWatch Logs Insights query. If the query has already ended, returns an error that the given query is not running.
 
     Usage: If a log query is started by execute_log_insights_query tool and has a polling time out, this tool can be used to cancel
     it prematurely to avoid incurring additional costs.

--- a/src/cloudwatch-mcp-server/README.md
+++ b/src/cloudwatch-mcp-server/README.md
@@ -1,46 +1,89 @@
-# AWS Labs cloudwatch-logs MCP Server
+# AWS Labs cloudwatch MCP Server
 
-An AWS Labs Model Context Protocol (MCP) server for Amazon CloudWatch
+An AWS Labs Model Context Protocol (MCP) server for CloudWatch provides AI-powered troubleshooting tools across metrics, alarms, logs, and traces, enabling rapid root cause analysis and intelligent recommendations. It offers comprehensive observability tools that simplify monitoring, reduce context switching, and help teams quickly diagnose and resolve service issues. This server will provide AI agents and application developers with seamless access to CloudWatch telemetry data through standardized MCP interfaces, eliminating the need for custom API solutions and reducing context switching during troubleshooting workflows. By consolidating access to all CloudWatch capabilities, we enable powerful cross-service correlations and insights that accelerate incident resolution and improve operational visibility.
 
 ## Instructions
 
-Use this MCP server to run commands on CloudWatch resources. Supports discovering logs groups as well as running CloudWatch Log Insight
-Queries. With CloudWatch Logs Insights, you can interactively search and analyze your log data in Amazon CloudWatch Logs and perform queries to help
-you more efficiently and effectively respond to operational issues.
+The CloudWatch MCP Server provides specialized tools to address common operational scenarios including alarm troubleshooting, understand metrics definitions,  alarm recommendations and log analysis. Each tool encapsulates multiple CloudWatch APIs into task-oriented operations. Along with specialized tools, each service offers core tools that enables seamless interaction with CloudWatch services.
 
 ## Features
 
-- Discovering log groups and metadata about them within your AWS account or accounts connected by CloudWatch Cross Account Observability
-- Converting human-readable questions and commands into CloudWatch Log Insight queries and executing them against the discovered log groups.
+Alarm Based Troubleshooting - Identifies active alarms, retrieves related metrics and logs, and analyzes historical alarm patterns to determine root causes of triggered alerts. Provides context-aware recommendations for remediation.
+
+API Gateway Lambda Diagnostics - Correlates API Gateway metrics with Lambda execution logs to pinpoint failures in serverless applications. Identifies cold starts, timeouts, and error patterns affecting API performance.
+
+Log Analyzer -  Analyzes a CloudWatch log group for anomalies, message patterns, and error patterns within a specified time window.
+
+SLO Compliance Analyzer - Evaluates Service Level Objective compliance by examining traces and logs for breached thresholds. Helps identify service dependencies contributing to SLO violations and recommend corrective actions.
+
+Metric Definition Analyzer - Provides comprehensive descriptions of what metrics represent, how they're calculated. Differentiates between standard and custom metrics.
+
+Alarm Recommendations - Suggests optimal alarm configurations based on historical patterns and best practices. Helps reduce false positives and ensure appropriate coverage of critical metrics.
+
 
 ## Prerequisites
 
 1. Install `uv` from [Astral](https://docs.astral.sh/uv/getting-started/installation/) or the [GitHub README](https://github.com/astral-sh/uv#installation)
 2. Install Python using `uv python install 3.10`
-3. An AWS account with [CloudWatch Log Groups](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_GettingStarted.html)
+3. An AWS account with [CloudWatch Telemetry](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html)
 4. This MCP server can only be run locally on the same host as your LLM client.
 5. Set up AWS credentials with access to AWS services
    - You need an AWS account with appropriate permissions
    - Configure AWS credentials with `aws configure` or environment variables
 
 ## Available Tools
-* `describe_log_groups` - Describe log groups in the account and region, including user saved queries applicable to them. Supports Cross Account Observability.
-* `analyze_log_group` - Analyzes a CloudWatch log group for anomalies, top message patterns, and top error patterns within a specified time window.
-Log group must have at least one [CloudWatch Log Anomaly Detector](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/LogsAnomalyDetection.html) configured to search for anomalies.
-* `execute_log_insights_query` - Execute a Log Insights query against one or more log groups. Will wait for the query to complete for a configurable timeout.
-* `get_query_results` - Get the results of a query previously started by `execute_log_insights_query`.
-* `cancel_query` - Cancel an ongoing query that was previously started by `execute_log_insights_query`.
+
+### Core Tools from CloudWatch Metrics
+* `get_metric_data` - Retrieves detailed metric data for any CloudWatch metric
+* `get_metric_metadata` - Retrieves retrieves comprehensive metadata about a specific CloudWatch metric
+* `get_recommended_metric_alarms` - Gets recommended alarms for a CloudWatch metric
+
+### Core Tools from CloudWatch Alarms
+* `get_active_alarms` - Identifies currently active alarms across the account
+* `get_alarm_history` - Retrieves historical alarm state changes and patterns
+
+### Core Tools from CloudWatch Dashboards
+* `list_dashboards` - Discovers available CloudWatch dashboards
+* `get_dashboard_data` - Retrieves the widgets and data from dashboards
+* `get_dashboard_recommendations` - Recommends dashboard improvements
+
+### Core Tools from CloudWatch Logs
+* `describe_log_groups` - Finds metadata about log groups
+* `analyze_log_group` - Analyzes logs for anomalies, message patterns, and error patterns
+* `execute_log_insights_query` - Executes queries with time-frame and query input
+* `get_logs_insight_query_results` - Retrieves results from executed queries
+* `cancel_logs_insight_query` - Cancels running queries
+
+### Core Tools from CloudWatch Application Signals
+* `list_monitored_services` - Lists all services monitored by Application Signals
+* `get_service_detail` - Gets health data for specific services
+* `get_service_metrics` - Queries CloudWatch metrics for monitored services
+* `list_slis` - Monitors SLI status and SLO compliance across services
+* `get_slo` - Gets SLO setup information in the account
+* `get_traces_for_slo` - Retrieves traces related to SLO breaches
+* `query_sampled_traces` - Queries AWS X-Ray traces data
+* `search_transaction_spans` - Queries OTel Spans data via Transaction Search
 
 ### Required IAM Permissions
-* `logs:Describe*`
-* `logs:Get*`
-* `logs:List*`
+* `cloudwatch:DescribeAlarms`
+* `cloudwatch:DescribeAlarmHistory`
+* `cloudwatch:GetMetricData`
+* `cloudwatch:ListMetrics`
+* `cloudwatch:GetMetricStatistics`
+* `cloudwatch:DescribeInsightRules`
+* `cloudwatch:GetInsightRuleReport`
+
+* `logs:DescribeLogGroups`
+* `logs:DescribeQueryDefinitions`
+* `logs:ListLogAnomalyDetectors`
+* `logs:ListAnomalies`
 * `logs:StartQuery`
+* `logs:GetQueryResults`
 * `logs:StopQuery`
 
 ## Installation
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=awslabs.cloudwatch-mcp-server&config=eyJhdXRvQXBwcm92ZSI6W10sImRpc2FibGVkIjpmYWxzZSwidGltZW91dCI6NjAsImNvbW1hbmQiOiJ1dnggYXdzbGFicy5jbG91ZHdhdGNoLW1jcC1zZXJ2ZXJAbGF0ZXN0IiwiZW52Ijp7IkFXU19QUk9GSUxFIjoiW1RoZSBBV1MgUHJvZmlsZSBOYW1lIHRvIHVzZSBmb3IgQVdTIGFjY2Vzc10iLCJBV1NfUkVHSU9OIjoiW1RoZSBBV1MgcmVnaW9uIHRvIHJ1biBpbl0iLCJGQVNUTUNQX0xPR19MRVZFTCI6IkVSUk9SIn0sInRyYW5zcG9ydFR5cGUiOiJzdGRpbyJ9)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=awslabs.cloudwatch-mcp-server&config=ewogICAgImF1dG9BcHByb3ZlIjogW10sCiAgICAiZGlzYWJsZWQiOiBmYWxzZSwKICAgICJ0aW1lb3V0IjogNjAsCiAgICAiY29tbWFuZCI6ICJ1dnggYXdzbGFicy5jbG91ZHdhdGNoLW1jcC1zZXJ2ZXJAbGF0ZXN0IiwKICAgICJlbnYiOiB7CiAgICAgICJBV1NfUFJPRklMRSI6ICJbVGhlIEFXUyBQcm9maWxlIE5hbWUgdG8gdXNlIGZvciBBV1MgYWNjZXNzXSIsCiAgICAgICJBV1NfUkVHSU9OIjogIltUaGUgQVdTIHJlZ2lvbiB0byBydW4gaW5dIiwKICAgICAgIkZBU1RNQ1BfTE9HX0xFVkVMIjogIkVSUk9SIgogICAgfSwKICAgICJ0cmFuc3BvcnRUeXBlIjogInN0ZGlvIgp)
 
 Example for Amazon Q Developer CLI (~/.aws/amazonq/mcp.json):
 

--- a/src/cloudwatch-mcp-server/README.md
+++ b/src/cloudwatch-mcp-server/README.md
@@ -1,6 +1,6 @@
 # AWS Labs cloudwatch MCP Server
 
-An AWS Labs Model Context Protocol (MCP) server for CloudWatch provides AI-powered troubleshooting tools across metrics, alarms, logs, and traces, enabling rapid root cause analysis and intelligent recommendations. It offers comprehensive observability tools that simplify monitoring, reduce context switching, and help teams quickly diagnose and resolve service issues. This server will provide AI agents and application developers with seamless access to CloudWatch telemetry data through standardized MCP interfaces, eliminating the need for custom API solutions and reducing context switching during troubleshooting workflows. By consolidating access to all CloudWatch capabilities, we enable powerful cross-service correlations and insights that accelerate incident resolution and improve operational visibility.
+An AWS Labs Model Context Protocol (MCP) server for CloudWatch provides AI-powered troubleshooting tools across metrics, alarms, and logs, enabling rapid root cause analysis and intelligent recommendations. It offers comprehensive observability tools that simplify monitoring, reduce context switching, and help teams quickly diagnose and resolve service issues. This server will provide AI agents and application developers with seamless access to CloudWatch telemetry data through standardized MCP interfaces, eliminating the need for custom API solutions and reducing context switching during troubleshooting workflows. By consolidating access to all CloudWatch capabilities, we enable powerful cross-service correlations and insights that accelerate incident resolution and improve operational visibility.
 
 ## Instructions
 
@@ -10,13 +10,9 @@ The CloudWatch MCP Server provides specialized tools to address common operation
 
 Alarm Based Troubleshooting - Identifies active alarms, retrieves related metrics and logs, and analyzes historical alarm patterns to determine root causes of triggered alerts. Provides context-aware recommendations for remediation.
 
-API Gateway Lambda Diagnostics - Correlates API Gateway metrics with Lambda execution logs to pinpoint failures in serverless applications. Identifies cold starts, timeouts, and error patterns affecting API performance.
-
 Log Analyzer -  Analyzes a CloudWatch log group for anomalies, message patterns, and error patterns within a specified time window.
 
-SLO Compliance Analyzer - Evaluates Service Level Objective compliance by examining traces and logs for breached thresholds. Helps identify service dependencies contributing to SLO violations and recommend corrective actions.
-
-Metric Definition Analyzer - Provides comprehensive descriptions of what metrics represent, how they're calculated. Differentiates between standard and custom metrics.
+Metric Definition Analyzer - Provides comprehensive descriptions of what metrics represent, how they're calculated. 
 
 Alarm Recommendations - Suggests optimal alarm configurations based on historical patterns and best practices. Helps reduce false positives and ensure appropriate coverage of critical metrics.
 
@@ -35,17 +31,12 @@ Alarm Recommendations - Suggests optimal alarm configurations based on historica
 
 ### Core Tools from CloudWatch Metrics
 * `get_metric_data` - Retrieves detailed metric data for any CloudWatch metric
-* `get_metric_metadata` - Retrieves retrieves comprehensive metadata about a specific CloudWatch metric
+* `get_metric_metadata` - Retrieves comprehensive metadata about a specific CloudWatch metric
 * `get_recommended_metric_alarms` - Gets recommended alarms for a CloudWatch metric
 
 ### Core Tools from CloudWatch Alarms
 * `get_active_alarms` - Identifies currently active alarms across the account
 * `get_alarm_history` - Retrieves historical alarm state changes and patterns
-
-### Core Tools from CloudWatch Dashboards
-* `list_dashboards` - Discovers available CloudWatch dashboards
-* `get_dashboard_data` - Retrieves the widgets and data from dashboards
-* `get_dashboard_recommendations` - Recommends dashboard improvements
 
 ### Core Tools from CloudWatch Logs
 * `describe_log_groups` - Finds metadata about log groups
@@ -54,24 +45,11 @@ Alarm Recommendations - Suggests optimal alarm configurations based on historica
 * `get_logs_insight_query_results` - Retrieves results from executed queries
 * `cancel_logs_insight_query` - Cancels running queries
 
-### Core Tools from CloudWatch Application Signals
-* `list_monitored_services` - Lists all services monitored by Application Signals
-* `get_service_detail` - Gets health data for specific services
-* `get_service_metrics` - Queries CloudWatch metrics for monitored services
-* `list_slis` - Monitors SLI status and SLO compliance across services
-* `get_slo` - Gets SLO setup information in the account
-* `get_traces_for_slo` - Retrieves traces related to SLO breaches
-* `query_sampled_traces` - Queries AWS X-Ray traces data
-* `search_transaction_spans` - Queries OTel Spans data via Transaction Search
-
 ### Required IAM Permissions
 * `cloudwatch:DescribeAlarms`
 * `cloudwatch:DescribeAlarmHistory`
 * `cloudwatch:GetMetricData`
 * `cloudwatch:ListMetrics`
-* `cloudwatch:GetMetricStatistics`
-* `cloudwatch:DescribeInsightRules`
-* `cloudwatch:GetInsightRuleReport`
 
 * `logs:DescribeLogGroups`
 * `logs:DescribeQueryDefinitions`
@@ -83,7 +61,7 @@ Alarm Recommendations - Suggests optimal alarm configurations based on historica
 
 ## Installation
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=awslabs.cloudwatch-mcp-server&config=ewogICAgImF1dG9BcHByb3ZlIjogW10sCiAgICAiZGlzYWJsZWQiOiBmYWxzZSwKICAgICJ0aW1lb3V0IjogNjAsCiAgICAiY29tbWFuZCI6ICJ1dnggYXdzbGFicy5jbG91ZHdhdGNoLW1jcC1zZXJ2ZXJAbGF0ZXN0IiwKICAgICJlbnYiOiB7CiAgICAgICJBV1NfUFJPRklMRSI6ICJbVGhlIEFXUyBQcm9maWxlIE5hbWUgdG8gdXNlIGZvciBBV1MgYWNjZXNzXSIsCiAgICAgICJBV1NfUkVHSU9OIjogIltUaGUgQVdTIHJlZ2lvbiB0byBydW4gaW5dIiwKICAgICAgIkZBU1RNQ1BfTE9HX0xFVkVMIjogIkVSUk9SIgogICAgfSwKICAgICJ0cmFuc3BvcnRUeXBlIjogInN0ZGlvIgp)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://www.cursor.com/install-mcp?name=awslabs.cloudwatch-mcp-server&config=eyJhdXRvQXBwcm92ZSI6W10sImRpc2FibGVkIjpmYWxzZSwidGltZW91dCI6NjAsImNvbW1hbmQiOiJ1dnggYXdzbGFicy5jbG91ZHdhdGNoLW1jcC1zZXJ2ZXJAbGF0ZXN0IiwiZW52Ijp7IkFXU19QUk9GSUxFIjoiW1RoZSBBV1MgUHJvZmlsZSBOYW1lIHRvIHVzZSBmb3IgQVdTIGFjY2Vzc10iLCJBV1NfUkVHSU9OIjoiW1RoZSBBV1MgcmVnaW9uIHRvIHJ1biBpbl0iLCJGQVNUTUNQX0xPR19MRVZFTCI6IkVSUk9SIn0sInRyYW5zcG9ydFR5cGUiOiJzdGRpbyJ9)
 
 Example for Amazon Q Developer CLI (~/.aws/amazonq/mcp.json):
 

--- a/src/cloudwatch-mcp-server/README.md
+++ b/src/cloudwatch-mcp-server/README.md
@@ -4,18 +4,17 @@ An AWS Labs Model Context Protocol (MCP) server for CloudWatch provides AI-power
 
 ## Instructions
 
-The CloudWatch MCP Server provides specialized tools to address common operational scenarios including alarm troubleshooting, understand metrics definitions,  alarm recommendations and log analysis. Each tool encapsulates multiple CloudWatch APIs into task-oriented operations. Along with specialized tools, each service offers core tools that enables seamless interaction with CloudWatch services.
+The CloudWatch MCP Server provides specialized tools to address common operational scenarios including alarm troubleshooting, understand metrics definitions, alarm recommendations and log analysis. Each tool encapsulates one or multiple CloudWatch APIs into task-oriented operations.
 
 ## Features
 
 Alarm Based Troubleshooting - Identifies active alarms, retrieves related metrics and logs, and analyzes historical alarm patterns to determine root causes of triggered alerts. Provides context-aware recommendations for remediation.
 
-Log Analyzer -  Analyzes a CloudWatch log group for anomalies, message patterns, and error patterns within a specified time window.
+Log Analyzer - Analyzes a CloudWatch log group for anomalies, message patterns, and error patterns within a specified time window.
 
-Metric Definition Analyzer - Provides comprehensive descriptions of what metrics represent, how they're calculated. 
+Metric Definition Analyzer - Provides comprehensive descriptions of what metrics represent, how they're calculated, recommended statistics to use for metric data retrieval
 
-Alarm Recommendations - Suggests optimal alarm configurations based on historical patterns and best practices. Helps reduce false positives and ensure appropriate coverage of critical metrics.
-
+Alarm Recommendations - Suggests optimal alarm configurations based on best practices. Helps reduce false positives and ensure appropriate coverage of critical metrics.
 
 ## Prerequisites
 

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_logs/models.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/cloudwatch_logs/models.py
@@ -53,7 +53,7 @@ class LogGroupMetadata(BaseModel):
         return v
 
 
-class SavedQuery(BaseModel):
+class SavedLogsInsightsQuery(BaseModel):
     """Represents a saved CloudWatch Logs Insights query."""
 
     logGroupNames: Set[str] = Field(
@@ -88,18 +88,18 @@ class SavedQuery(BaseModel):
         return values
 
 
-class LogMetadata(BaseModel):
+class LogsMetadata(BaseModel):
     """Represents information about a CloudWatch log."""
 
     log_group_metadata: List[LogGroupMetadata] = Field(
         ..., description='List of metadata about log groups'
     )
-    saved_queries: List[SavedQuery] = Field(
+    saved_queries: List[SavedLogsInsightsQuery] = Field(
         ..., description='Saved queries associated with the log'
     )
 
 
-class AnomalyDetector(BaseModel):
+class LogAnomalyDetector(BaseModel):
     """Represents a CloudWatch Logs Anomaly Detector."""
 
     anomalyDetectorArn: str = Field(..., description='The ARN of the anomaly detector')
@@ -163,7 +163,7 @@ class LogAnomaly(BaseModel):
 class LogAnomalyResults(BaseModel):
     """Represents the results of a log anomaly query."""
 
-    anomaly_detectors: List[AnomalyDetector] = Field(
+    anomaly_detectors: List[LogAnomalyDetector] = Field(
         ..., description='List of anomaly detectors monitoring this log group'
     )
     anomalies: List[LogAnomaly] = Field(
@@ -171,7 +171,7 @@ class LogAnomalyResults(BaseModel):
     )
 
 
-class LogAnalysisResult(BaseModel):
+class LogsAnalysisResult(BaseModel):
     """Result of analyzing a log group."""
 
     log_anomaly_results: LogAnomalyResults = Field(
@@ -185,9 +185,9 @@ class LogAnalysisResult(BaseModel):
     )
 
 
-class CancelQueryResult(BaseModel):
-    """Result of canceling a query."""
+class LogsQueryCancelResult(BaseModel):
+    """Result of canceling Logs Insight query."""
 
     success: bool = Field(
-        ..., description='True if the query was successfully cancelled, false otherwise'
+        ..., description='True if the logs insight query was successfully cancelled, false otherwise'
     )

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/server.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/server.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""awslabs cloudwatch-logs MCP Server implementation."""
+"""awslabs cloudwatch MCP Server implementation."""
 
 from awslabs.cloudwatch_mcp_server.cloudwatch_logs.tools import CloudWatchLogsTools
 from awslabs.cloudwatch_mcp_server.cloudwatch_metrics.tools import CloudWatchMetricsTools

--- a/src/cloudwatch-mcp-server/tests/cloudwatch_logs/test_logs_models.py
+++ b/src/cloudwatch-mcp-server/tests/cloudwatch_logs/test_logs_models.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the cloudwatch-logs MCP Server models."""
+"""Tests for the CloudWatch Logs models."""
 
 from awslabs.cloudwatch_mcp_server.cloudwatch_logs.models import (
     LogAnomaly,

--- a/src/cloudwatch-mcp-server/tests/cloudwatch_logs/test_logs_server.py
+++ b/src/cloudwatch-mcp-server/tests/cloudwatch_logs/test_logs_server.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the cloudwatch-logs MCP Server."""
+"""Tests for the CloudWatch Logs functionality in the MCP Server."""
 
 import boto3
 import os

--- a/src/cloudwatch-mcp-server/tests/cloudwatch_logs/test_logs_server.py
+++ b/src/cloudwatch-mcp-server/tests/cloudwatch_logs/test_logs_server.py
@@ -18,9 +18,9 @@ import os
 import pytest
 import pytest_asyncio
 from awslabs.cloudwatch_mcp_server.cloudwatch_logs.models import (
-    CancelQueryResult,
-    LogAnalysisResult,
-    LogMetadata,
+    LogsQueryCancelResult,
+    LogsAnalysisResult,
+    LogsMetadata,
 )
 from awslabs.cloudwatch_mcp_server.cloudwatch_logs.tools import CloudWatchLogsTools
 from moto import mock_aws
@@ -107,7 +107,7 @@ class TestDescribeLogGroups:
         )
 
         # Verify results
-        assert isinstance(result, LogMetadata)
+        assert isinstance(result, LogsMetadata)
         assert len(result.log_group_metadata) == 1
         assert result.log_group_metadata[0].logGroupName == '/aws/test/group1'
         assert len(result.saved_queries) == 1
@@ -174,7 +174,7 @@ class TestDescribeLogGroups:
         )
 
         # Verify results
-        assert isinstance(result, LogMetadata)
+        assert isinstance(result, LogsMetadata)
         assert len(result.log_group_metadata) == 1
         assert len(result.saved_queries) == 1
 
@@ -303,7 +303,7 @@ class TestGetQueryResults:
         )
 
         # Call the tool
-        result = await cloudwatch_tools.get_query_results(ctx, query_id='test-query-id')
+        result = await cloudwatch_tools.get_logs_insight_query_results(ctx, query_id='test-query-id')
 
         # Verify results
         assert result['queryId'] == 'test-query-id'
@@ -322,10 +322,10 @@ class TestCancelQuery:
         cloudwatch_tools.logs_client.stop_query = MagicMock(return_value={'success': True})
 
         # Call the tool
-        result = await cloudwatch_tools.cancel_query(ctx, query_id='test-query-id')
+        result = await cloudwatch_tools.cancel_logs_insight_query(ctx, query_id='test-query-id')
 
         # Verify results
-        assert isinstance(result, CancelQueryResult)
+        assert isinstance(result, LogsQueryCancelResult)
         assert result.success is True
 
 
@@ -387,7 +387,7 @@ class TestAnalyzeLogGroup:
             )
 
         # Verify results
-        assert isinstance(result, LogAnalysisResult)
+        assert isinstance(result, LogsAnalysisResult)
         assert len(result.log_anomaly_results.anomaly_detectors) == 1
         assert result.log_anomaly_results.anomaly_detectors[0].detectorName == 'test-detector'
         assert 'results' in result.top_patterns


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Deprecate CloudWatch Logs Server. Refactor CloudWatch Logs tools within CloudWatch Server and update README for CloudWatch MCP server

Changes
- Refactored CloudWatch Logs tools to be consistent with other CloudWatch Tools
- Updated README for instructions, tools and configs
- Updated index and main README to deprecate CloudWatch Logs tools
- Updated CWL tools description to deprecate them and reference the cloudwatch tools


### User experience

Before this change there existed CloudWatch Logs and CloudWatch MCP servers. CloudWatchLogs tools in CloudWatch service used generic names and could have caused AI to hallucinate as there are multiple tools with similar names in metrics space. After this change, there is one unified server for CloudWatch services and there will be clear distinction between metrics and logs tools within CloudWatch MCP server. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
